### PR TITLE
yotaro-new-feature/add-azure-managed-resource-group-name

### DIFF
--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection/README.md
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection/README.md
@@ -129,6 +129,8 @@ You can use the `terraform.tfvars.example` file as a base for your variables. Le
     - The CIDR address of the first subnet
 - subnet_private_cidr
     - The CIDR address of the second subnet
+- managed_resource_group_name
+    - The name of the managed resource group
 
 
 ## Deploy

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection/tf/databricks.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection/tf/databricks.tf
@@ -4,6 +4,7 @@ resource "azurerm_databricks_workspace" "this" {
   location            = azurerm_resource_group.this.location
   sku                 = "premium"
   tags                = var.tags
+  managed_resource_group_name = var.managed_resource_group_name
 
   custom_parameters {
     virtual_network_id                                   = local.vnet.id

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection/tf/terraform.tfvars.example
@@ -20,6 +20,7 @@ location = "westeurope"
 databricks_account_id = "xxx-xxx"
 existing_metastore_id = "xxx-xxx"
 new_metastore_name = ""
+managed_resource_group_name = null #optional. if no name is provided, azure will generate one on it's own
 
 # =============================================================================
 # Network Configuration

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection/tf/variables.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection/tf/variables.tf
@@ -17,6 +17,16 @@ variable "resource_group_name" {
     type        = string
 }
 
+variable "managed_resource_group_name" {
+    description = "The name of managed resource group. This is optional field"
+    type = string
+    default     = null
+    validation {
+    condition     = var.managed_resource_group_name != var.resource_group_name
+    error_message = "Managed resource group name should not be same as resource group name"
+  }
+}
+
 variable "tags" {
     description = "A map of tags to assign to the resources"
     type        = map(string)


### PR DESCRIPTION
…oup_name = var.managed_resource_group_name to resource azurerm_databricks_workspace, Added managed_resource_group_name to tfvars, Edited README

# Pull Request

## Description
Currently, the azure-vnet-injection TF always generates the managed resource group name randomly.
Added a variable related to the managed resource group name, so that users can specify it when needed.

## Category
- [ ] core-platform
- [ ] data-engineering
- [ ] data-governance
- [ ] data-warehousing  
- [ ] genai-ml
- [ ] launch-accelerator
- [x] workspace-setup

## Type of Change
- [ ] New project
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation

## Project Details
**Project Name:** 
**Purpose:** 
**Technologies Used:** 

## Testing
- [x] Code runs without errors
- [x] Documentation is complete
- [x] Used only synthetic data

## Security Compliance ✅
- [x] No customer data, PII, or proprietary information
- [x] No credentials or access tokens
- [x] Only synthetic data used
- [x] Third-party licenses acknowledged

---

**By submitting this PR, I confirm I have followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and security requirements.**