### PR TITLE
Fixed VNet and resource group dependency

### DIFF
--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection/tf/network.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection/tf/network.tf
@@ -6,6 +6,7 @@ resource "azurerm_virtual_network" "this" {
   resource_group_name = var.vnet_resource_group_name
   address_space       = [var.cidr]
   tags                = var.tags
+  depends_on = [azurerm_resource_group.vnet_resource_group[0]]
 }
 
 resource "azurerm_resource_group" "vnet_resource_group" {


### PR DESCRIPTION
# Pull Request

## Description
Added a dependency between the VNet and its resource group. This is essential when the customer creates a new VNet.

## Category
- [ ] core-platform
- [ ] data-engineering
- [ ] data-governance
- [ ] data-warehousing  
- [ ] genai-ml
- [ ] launch-accelerator
- [x] workspace-setup

## Type of Change
- [ ] New project
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Project Details
**Project Name:** Azure VNet injection Workspace Setup Guide (with VNet deployment)
**Purpose:** Infrastructure deployment
**Technologies Used:** Terraform

## Testing
- [x] Code runs without errors
- [x] Documentation is complete
- [x] Used only synthetic data

## Security Compliance ✅
- [x] No customer data, PII, or proprietary information
- [x] No credentials or access tokens
- [x] Only synthetic data used
- [x] Third-party licenses acknowledged

---

**By submitting this PR, I confirm I have followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and security requirements.**