### PR TITLE
Add new_security_group option to create dedicated SG

### DIFF
--- a/workspace-setup/terraform-examples/aws/aws-byovpc/README.md
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/README.md
@@ -133,6 +133,15 @@ security_group_ids = ["sg-xxxxxxxxx"]
 - Subnets must have outbound internet connectivity (NAT Gateway or similar)
 - Security group must allow required Databricks ports
 
+### Security Group Configuration
+
+Leave `security_group_ids` empty to automatically create a dedicated security group. Optionally, customize the name via `new_security_group_name` (defaults to `<resource_prefix>-databricks-sg`).
+
+```hcl
+security_group_ids      = []
+new_security_group_name = "my-databricks-sg"  # optional
+```
+
 ### Unity Catalog Options
 
 #### Create New Metastore

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/README.md
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/README.md
@@ -125,7 +125,7 @@ security_group_ids   = []
 ```hcl
 vpc_id             = "vpc-xxxxxxxxx"
 subnet_ids         = ["subnet-xxxxxxxxx", "subnet-yyyyyyyyy"]
-security_group_ids = ["sg-xxxxxxxxx"]
+security_group_ids = ["sg-xxxxxxxxx"]  # leave empty to auto-create, or provide existing SG IDs
 ```
 
 **Requirements for existing VPC:**
@@ -135,7 +135,7 @@ security_group_ids = ["sg-xxxxxxxxx"]
 
 ### Security Group Configuration
 
-Leave `security_group_ids` empty to automatically create a dedicated security group. Optionally, customize the name via `new_security_group_name` (defaults to `<resource_prefix>-databricks-sg`).
+Leave `security_group_ids` empty to automatically create a dedicated security group in the target VPC (works for both new and existing VPCs). Optionally, customize the name via `new_security_group_name` (defaults to `<resource_prefix>-databricks-sg`).
 
 ```hcl
 security_group_ids      = []

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/outputs.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/outputs.tf
@@ -48,7 +48,7 @@ output "nat_gateway_ids" {
 
 output "security_group_id" {
   description = "ID of the security group used for the workspace"
-  value       = length(var.security_group_ids) > 0 ? var.security_group_ids[0] : (var.vpc_id == "" ? module.vpc[0].default_security_group_id : "")
+  value = length(var.security_group_ids) > 0 ? var.security_group_ids[0] : one(aws_security_group.databricks[*].id)
 }
 
 # =============================================================================

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/outputs.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/outputs.tf
@@ -46,9 +46,9 @@ output "nat_gateway_ids" {
   value       = var.vpc_id == "" ? module.vpc[0].natgw_ids : []
 }
 
-output "security_group_id" {
-  description = "ID of the security group used for the workspace"
-  value = length(var.security_group_ids) > 0 ? var.security_group_ids[0] : one(aws_security_group.databricks[*].id)
+output "security_group_ids" {
+  description = "IDs of the security groups used for the workspace"
+  value       = length(var.security_group_ids) > 0 ? var.security_group_ids : aws_security_group.databricks[*].id
 }
 
 # =============================================================================

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/security_group.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/security_group.tf
@@ -1,41 +1,48 @@
-resource "aws_vpc_security_group_egress_rule" "default_sg_egress_ports" {
-  for_each          = var.vpc_id == "" ? { for port in var.sg_egress_ports : tostring(port) => port } : {}
-  security_group_id = module.vpc[0].default_security_group_id
-  from_port         = each.value
-  to_port           = each.value
-  ip_protocol       = "tcp"
-  cidr_ipv4         = "0.0.0.0/0"
-  description       = "Allow outbound TCP traffic on port ${each.value}"
-  depends_on        = [module.vpc]
-}
+resource "aws_security_group" "databricks" {
+  count = var.vpc_id == "" ? 1 : 0
+  name        = var.new_security_group_name != "" ? var.new_security_group_name : "${var.resource_prefix}-databricks-sg"
+  description = "Dedicated security group for Databricks workspace"
+  vpc_id      = module.vpc[0].vpc_id
 
-resource "aws_vpc_security_group_egress_rule" "default_sg_internal_tcp_egress" {
-  count                        = var.vpc_id == "" ? 1 : 0
-  security_group_id            = module.vpc[0].default_security_group_id
-  referenced_security_group_id = module.vpc[0].default_security_group_id
-  ip_protocol                  = "tcp"
-  from_port                    = 0
-  to_port                      = 65535
-  description                  = "Allow all internal TCP egress traffic"
-  depends_on                   = [module.vpc]
-}
+  dynamic "egress" {
+    for_each = var.sg_egress_ports
+    content {
+      from_port   = egress.value
+      to_port     = egress.value
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow outbound TCP traffic on port ${egress.value}"
+    }
+  }
 
-resource "aws_vpc_security_group_egress_rule" "default_sg_internal_udp_egress" {
-  count                        = var.vpc_id == "" ? 1 : 0
-  security_group_id            = module.vpc[0].default_security_group_id
-  referenced_security_group_id = module.vpc[0].default_security_group_id
-  ip_protocol                  = "udp"
-  from_port                    = 0
-  to_port                      = 65535
-  description                  = "Allow all internal UDP egress traffic"
-  depends_on                   = [module.vpc]
-}
+  egress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    self        = true
+    description = "Allow all internal TCP egress traffic"
+  }
 
-resource "aws_vpc_security_group_ingress_rule" "default_sg_self_ingress" {
-  count                        = var.vpc_id == "" ? 1 : 0
-  security_group_id            = module.vpc[0].default_security_group_id
-  referenced_security_group_id = module.vpc[0].default_security_group_id
-  ip_protocol                  = "-1"
-  description                  = "Allow all traffic from self"
-  depends_on                   = [module.vpc]
+  egress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "udp"
+    self        = true
+    description = "Allow all internal UDP egress traffic"
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+    description = "Allow all traffic from self"
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Project = var.resource_prefix
+    }
+  )
 }

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/security_group.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/security_group.tf
@@ -1,8 +1,8 @@
 resource "aws_security_group" "databricks" {
-  count = var.vpc_id == "" ? 1 : 0
+  count       = length(var.security_group_ids) == 0 ? 1 : 0
   name        = var.new_security_group_name != "" ? var.new_security_group_name : "${var.resource_prefix}-databricks-sg"
   description = "Dedicated security group for Databricks workspace"
-  vpc_id      = module.vpc[0].vpc_id
+  vpc_id      = var.vpc_id == "" ? module.vpc[0].vpc_id : var.vpc_id
 
   dynamic "egress" {
     for_each = var.sg_egress_ports

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/terraform.tfvars.example
@@ -48,8 +48,11 @@ intra_subnet_cidr    = ["10.0.201.0/24"]
 # Security Group Configuration
 # =============================================================================
 
-# Optional: Use existing security groups (leave empty to use VPC default)
+# Use existing security groups (leave empty for dedicated security group to be created automatically)
 security_group_ids = []
+
+# Optional: Set custom security group name (defaults to '<resource_prefix>-databricks-sg' if left empty)
+# new_security_group_name = "my-databricks-sg"
 
 # Egress ports for Databricks connectivity
 sg_egress_ports = [443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/variables.tf
@@ -119,6 +119,12 @@ variable "sg_egress_ports" {
   default     = [443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
 }
 
+variable "new_security_group_name" {
+  description = "Name for the new security group. Required when new_security_group is true."
+  type        = string
+  default     = ""
+}
+
 # =============================================================================
 # Unity Catalog Metastore Configuration
 # =============================================================================

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/workspace.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/workspace.tf
@@ -35,7 +35,7 @@ resource "databricks_mws_networks" "this" {
   provider           = databricks.mws
   account_id         = var.databricks_account_id
   network_name       = "${var.prefix}-network"
-  security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : [module.vpc[0].default_security_group_id]
+  security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : aws_security_group.databricks[*].id
   subnet_ids         = length(var.subnet_ids) > 0 ? var.subnet_ids : module.vpc[0].private_subnets
   vpc_id             = var.vpc_id == "" ? module.vpc[0].vpc_id : var.vpc_id
 }

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/workspace.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/workspace.tf
@@ -1,7 +1,7 @@
 resource "null_resource" "previous" {}
 
 resource "time_sleep" "wait_30_seconds" {
-  depends_on      = [null_resource.previous]
+  depends_on      = [aws_iam_role.cross_account_role, aws_iam_role_policy.this]
   create_duration = "30s"
 }
 

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/workspace.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/workspace.tf
@@ -38,6 +38,13 @@ resource "databricks_mws_networks" "this" {
   security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : aws_security_group.databricks[*].id
   subnet_ids         = length(var.subnet_ids) > 0 ? var.subnet_ids : module.vpc[0].private_subnets
   vpc_id             = var.vpc_id == "" ? module.vpc[0].vpc_id : var.vpc_id
+
+  lifecycle {
+    precondition {
+      condition     = var.vpc_id == "" || length(var.subnet_ids) >= 2
+      error_message = "When `vpc_id` is set, `subnet_ids` must contain at least 2 subnet IDs."
+    }
+  }
 }
 
 resource "time_sleep" "wait_2_minutes" {


### PR DESCRIPTION
Adds new_security_group and new_security_group_name variables so users can choose between modifying the default VPC security group or creating a new dedicated one.