### PR TITLE
Add cluster creation to azure-vnet-injection-uc

### DIFF
--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/README.md
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/README.md
@@ -1,6 +1,6 @@
 # Azure VNet injection with User-Defined Catalog Workspace Setup Guide (with VNet deployment)
 
-This Terraform example deploys an Azure Databricks workspace with VNet Injection, Unity Catalog, and a user-defined catalog with an external location. It provisions the full networking stack (VNet, subnets, NSG, NAT Gateway), a Databricks workspace with Secure Cluster Connectivity (No Public IP), and configures Unity Catalog with a storage credential, external location, and user-defined catalog backed by an Azure Storage Account.
+This Terraform example deploys an Azure Databricks workspace with VNet Injection, Unity Catalog, and a user-defined catalog with an external location. It provisions the full networking stack (VNet, subnets, NSG, NAT Gateway), a Databricks workspace with Secure Cluster Connectivity (No Public IP), configures Unity Catalog with a storage credential, external location, and user-defined catalog backed by an Azure Storage Account, and creates a single-node Databricks cluster on the latest LTS runtime governed by the built-in **Personal Compute** cluster policy.
 
 It is important to note that this deployment creates a new virtual network from scratch and currently does not support using an existing VNet.
 
@@ -115,6 +115,7 @@ The code provisions:
 9. **Storage credential** – A Unity Catalog storage credential backed by the managed identity.
 10. **External location** – Points to the storage container using the storage credential.
 11. **User-defined catalog** – A Unity Catalog catalog backed by the external location's storage.
+12. **Single-node cluster** – A UC-compatible cluster attached to the built-in **Personal Compute** policy, which enforces Single User access mode, the single-node profile, and other UC-safe defaults. Overrides set by this template: latest LTS Databricks Runtime (via the `databricks_spark_version` data source), node type (`var.node_type_id`), idle auto-termination (`var.autotermination_minutes`, default `10`), and a `ClusterType = TerraformDeploymentTesting` custom tag. The cluster is created after the metastore assignment and workspace admin permission so UC is fully wired up before it boots. Single-user ownership is set by the policy to whoever runs `terraform apply`.
 
 ### Variables
 
@@ -137,6 +138,8 @@ Copy `terraform.tfvars.example` to `terraform.tfvars` in the `tf/` directory and
 | `location` | **(Required)** Azure region for all resources (e.g. `eastus`). See [supported regions](https://learn.microsoft.com/en-us/azure/databricks/resources/supported-regions). |
 | `existing_metastore_id` | **(Optional)** ID of an existing metastore. Leave empty to create a new one. When set, `admin_user` must have the `CREATE EXTERNAL LOCATION` privilege on that metastore. |
 | `new_metastore_name` | **(Optional)** Name for the new metastore. Required when `existing_metastore_id` is empty. |
+| `node_type_id` | **(Optional)** Azure VM SKU used for the single-node UC cluster driver. Default: `Standard_DS3_v2`. |
+| `autotermination_minutes` | **(Optional)** Idle minutes before the single-node cluster auto-terminates. Default: `10`. Minimum: `10`. Must fit within the Personal Compute policy's allowed range in your workspace. |
 | `vnet_name` | **(Required)** Name of the virtual network. |
 | `vnet_resource_group_name` | **(Required)** Name of the resource group for the VNet and networking resources. Must differ from `resource_group_name`. |
 | `cidr` | **(Optional)** CIDR for the VNet address space. Default: `10.0.0.0/20`. |
@@ -167,18 +170,21 @@ terraform output workspace_url
 
 # Get the workspace ID
 terraform output workspace_id
+
+# Get the cluster ID created by Terraform
+terraform output cluster_id
 ```
 
-Navigate to the workspace URL and log in with your Databricks credentials.
+Navigate to the workspace URL and log in with your Databricks credentials. The pre-created single-node cluster is visible under **Compute**.
 
 ## Validation
 
 To verify the deployment succeeded:
 
-1. **Terraform outputs** – From the `tf/` directory, run `terraform output` and confirm `workspace_url`, `workspace_id`, `resource_group_name`, and `vnet_id` are present and non-empty.
+1. **Terraform outputs** – From the `tf/` directory, run `terraform output` and confirm `workspace_url`, `workspace_id`, `cluster_id`, and `vnet_id` are present and non-empty.
 2. **Azure portal** – In your subscription, check that the resource group, VNet, subnets, NAT gateway, and the Databricks workspace exist and are in "Succeeded" or "Ready" state.
 3. **Workspace access** – Open `terraform output -raw workspace_url` in a browser and sign in (public access is always enabled).
-4. **Classic cluster** – Create and start a **classic cluster** (Compute → Create cluster; use the default "Standard” cluster type, not high-concurrency/shared). Once the cluster is in "Running" state, the setup is proven.
+4. **Single-node cluster** – Under **Compute**, locate the cluster named `<workspace_name>-uc-cluster`. Confirm the **Policy** field is `Personal Compute`, access mode is **Single user**, runtime is the latest LTS, node type matches `var.node_type_id`, auto-termination matches `var.autotermination_minutes` (default `10`), and the cluster carries the `ClusterType = TerraformDeploymentTesting` tag. Start the cluster and wait for "Running".
 
 ## Clean-up
 
@@ -209,6 +215,7 @@ This project uses a flat, organized structure with purpose-specific files instea
 ```
 tf/
 ├── azure.tf                    # Azure resources
+├── cluster.tf                  # UC-compatible single-node cluster
 ├── databricks.tf               # Databricks workspace
 ├── network.tf                  # VNet, subnets, and networking
 ├── outputs.tf                  # All output values
@@ -222,6 +229,7 @@ tf/
 | File | Purpose |
 |------|--------|
 | **azure.tf** | Resource group for the Databricks workspace and Unity Catalog resources. |
+| **cluster.tf** | `databricks_spark_version` (latest LTS) and `databricks_cluster_policy` ("Personal Compute") data sources, plus the `databricks_cluster` resource attached to the Personal Compute policy. Overrides node type, Spark version, auto-termination minutes, and the `ClusterType` tag. Depends on metastore assignment and workspace admin permission. |
 | **databricks.tf** | `azurerm_databricks_workspace` (Premium, VNet injection, No Public IP); metastore creation or assignment; workspace admin permissions; metastore owner group. |
 | **network.tf** | VNet resource group; VNet (address_space from `cidr`); NSG; public and private subnets (CIDRs from `subnet_public_cidr` and `subnet_private_cidr`); NAT Gateway with public IP and subnet associations. |
 | **providers.tf** | Azure and Databricks providers (workspace-level via workspace URL, account-level via accounts endpoint). Auth via Azure CLI. |
@@ -229,7 +237,7 @@ tf/
 | **terraform.tfvars.example** | Example variable values; copy to `terraform.tfvars` and set subscription, tenant, VNet CIDR, subnet CIDRs, location, etc. |
 | **versions.tf** | Terraform and provider version constraints (azurerm, databricks). |
 | **unity_catalog.tf** | Access connector (managed identity), storage account and container, role assignment, storage credential, external location, and user-defined catalog. |
-| **outputs.tf** | Workspace URL/ID; managed resource group ID; VNet ID; public and private subnet IDs; NSG ID; NAT gateway ID and public IP; catalog and external location names. |
+| **outputs.tf** | Workspace URL/ID; cluster ID; managed resource group ID; VNet ID; public and private subnet IDs; NSG ID; NAT gateway ID and public IP; catalog and external location names. |
 
 **Note:** There is no `main.tf` file in this project. Instead, resources are organized into descriptive, purpose-specific files. 
 

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/README.md
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/README.md
@@ -115,7 +115,7 @@ The code provisions:
 9. **Storage credential** – A Unity Catalog storage credential backed by the managed identity.
 10. **External location** – Points to the storage container using the storage credential.
 11. **User-defined catalog** – A Unity Catalog catalog backed by the external location's storage.
-12. **Single-node cluster** – A UC-compatible cluster attached to the built-in **Personal Compute** policy, which enforces Single User access mode, the single-node profile, and other UC-safe defaults. Overrides set by this template: latest LTS Databricks Runtime (via the `databricks_spark_version` data source), node type (`var.node_type_id`), idle auto-termination (`var.autotermination_minutes`, default `10`), access mode (`var.data_security_mode`, default `SINGLE_USER`), and a `ClusterType = TerraformDeploymentTesting` custom tag. The cluster is created after the metastore assignment and workspace admin permission so UC is fully wired up before it boots. Single-user ownership is assigned to `var.admin_user`.
+12. **Single-node cluster** – A UC-compatible cluster attached to the built-in **Personal Compute** policy, which enforces Single User access mode, the single-node profile, and other UC-safe defaults. Overrides set by this template: latest LTS Databricks Runtime (via the `databricks_spark_version` data source), node type (`var.node_type_id`), idle auto-termination (`var.cluster_autotermination_minutes`, default `10`), access mode (constant `SINGLE_USER`), and a `ClusterType = TerraformDeploymentTesting` custom tag. The cluster is created after the metastore assignment and workspace admin permission so UC is fully wired up before it boots. Single-user ownership is assigned to `var.admin_user`.
 
 ### Variables
 
@@ -139,8 +139,7 @@ Copy `terraform.tfvars.example` to `terraform.tfvars` in the `tf/` directory and
 | `existing_metastore_id` | **(Optional)** ID of an existing metastore. Leave empty to create a new one. When set, `admin_user` must have the `CREATE EXTERNAL LOCATION` privilege on that metastore. |
 | `new_metastore_name` | **(Optional)** Name for the new metastore. Required when `existing_metastore_id` is empty. |
 | `node_type_id` | **(Optional)** Azure VM SKU used for the single-node UC cluster driver. Default: `Standard_DS3_v2`. |
-| `autotermination_minutes` | **(Optional)** Idle minutes before the single-node cluster auto-terminates. Default: `10`. Minimum: `10`. Must fit within the Personal Compute policy's allowed range in your workspace. |
-| `data_security_mode` | **(Optional)** Access mode for the UC-compatible single-node cluster. Default: `SINGLE_USER` (required by the Personal Compute policy). Allowed values: `SINGLE_USER`, `USER_ISOLATION`, `NONE`, `LEGACY_TABLE_ACL`, `LEGACY_PASSTHROUGH`, `LEGACY_SINGLE_USER`, `LEGACY_SINGLE_USER_STANDARD`. |
+| `cluster_autotermination_minutes` | **(Optional)** Idle minutes before the single-node cluster auto-terminates. Default: `10`. Minimum: `10`. Must fit within the Personal Compute policy's allowed range in your workspace. |
 | `vnet_name` | **(Required)** Name of the virtual network. |
 | `vnet_resource_group_name` | **(Required)** Name of the resource group for the VNet and networking resources. Must differ from `resource_group_name`. |
 | `cidr` | **(Optional)** CIDR for the VNet address space. Default: `10.0.0.0/20`. |
@@ -185,7 +184,7 @@ To verify the deployment succeeded:
 1. **Terraform outputs** – From the `tf/` directory, run `terraform output` and confirm `workspace_url`, `workspace_id`, `cluster_id`, and `vnet_id` are present and non-empty.
 2. **Azure portal** – In your subscription, check that the resource group, VNet, subnets, NAT gateway, and the Databricks workspace exist and are in "Succeeded" or "Ready" state.
 3. **Workspace access** – Open `terraform output -raw workspace_url` in a browser and sign in (public access is always enabled).
-4. **Single-node cluster** – Under **Compute**, locate the cluster named `<workspace_name>-uc-cluster`. Confirm the **Policy** field is `Personal Compute`, access mode matches `var.data_security_mode` (default **Single user**), runtime is the latest LTS, node type matches `var.node_type_id`, auto-termination matches `var.autotermination_minutes` (default `10`), and the cluster carries the `ClusterType = TerraformDeploymentTesting` tag. Start the cluster and wait for "Running".
+4. **Single-node cluster** – Under **Compute**, locate the cluster named `<workspace_name>-uc-cluster`. Confirm the **Policy** field is `Personal Compute`, access mode matches `var.data_security_mode` (default **Single user**), runtime is the latest LTS, node type matches `var.node_type_id`, auto-termination matches `var.cluster_autotermination_minutes` (default `10`), and the cluster carries the `ClusterType = TerraformDeploymentTesting` tag. Start the cluster and wait for "Running".
 
 ## Clean-up
 

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/README.md
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/README.md
@@ -115,7 +115,7 @@ The code provisions:
 9. **Storage credential** – A Unity Catalog storage credential backed by the managed identity.
 10. **External location** – Points to the storage container using the storage credential.
 11. **User-defined catalog** – A Unity Catalog catalog backed by the external location's storage.
-12. **Single-node cluster** – A UC-compatible cluster attached to the built-in **Personal Compute** policy, which enforces Single User access mode, the single-node profile, and other UC-safe defaults. Overrides set by this template: latest LTS Databricks Runtime (via the `databricks_spark_version` data source), node type (`var.node_type_id`), idle auto-termination (`var.autotermination_minutes`, default `10`), and a `ClusterType = TerraformDeploymentTesting` custom tag. The cluster is created after the metastore assignment and workspace admin permission so UC is fully wired up before it boots. Single-user ownership is set by the policy to whoever runs `terraform apply`.
+12. **Single-node cluster** – A UC-compatible cluster attached to the built-in **Personal Compute** policy, which enforces Single User access mode, the single-node profile, and other UC-safe defaults. Overrides set by this template: latest LTS Databricks Runtime (via the `databricks_spark_version` data source), node type (`var.node_type_id`), idle auto-termination (`var.autotermination_minutes`, default `10`), access mode (`var.data_security_mode`, default `SINGLE_USER`), and a `ClusterType = TerraformDeploymentTesting` custom tag. The cluster is created after the metastore assignment and workspace admin permission so UC is fully wired up before it boots. Single-user ownership is assigned to `var.admin_user`.
 
 ### Variables
 
@@ -140,6 +140,7 @@ Copy `terraform.tfvars.example` to `terraform.tfvars` in the `tf/` directory and
 | `new_metastore_name` | **(Optional)** Name for the new metastore. Required when `existing_metastore_id` is empty. |
 | `node_type_id` | **(Optional)** Azure VM SKU used for the single-node UC cluster driver. Default: `Standard_DS3_v2`. |
 | `autotermination_minutes` | **(Optional)** Idle minutes before the single-node cluster auto-terminates. Default: `10`. Minimum: `10`. Must fit within the Personal Compute policy's allowed range in your workspace. |
+| `data_security_mode` | **(Optional)** Access mode for the UC-compatible single-node cluster. Default: `SINGLE_USER` (required by the Personal Compute policy). Allowed values: `SINGLE_USER`, `USER_ISOLATION`, `NONE`, `LEGACY_TABLE_ACL`, `LEGACY_PASSTHROUGH`, `LEGACY_SINGLE_USER`, `LEGACY_SINGLE_USER_STANDARD`. |
 | `vnet_name` | **(Required)** Name of the virtual network. |
 | `vnet_resource_group_name` | **(Required)** Name of the resource group for the VNet and networking resources. Must differ from `resource_group_name`. |
 | `cidr` | **(Optional)** CIDR for the VNet address space. Default: `10.0.0.0/20`. |
@@ -184,7 +185,7 @@ To verify the deployment succeeded:
 1. **Terraform outputs** – From the `tf/` directory, run `terraform output` and confirm `workspace_url`, `workspace_id`, `cluster_id`, and `vnet_id` are present and non-empty.
 2. **Azure portal** – In your subscription, check that the resource group, VNet, subnets, NAT gateway, and the Databricks workspace exist and are in "Succeeded" or "Ready" state.
 3. **Workspace access** – Open `terraform output -raw workspace_url` in a browser and sign in (public access is always enabled).
-4. **Single-node cluster** – Under **Compute**, locate the cluster named `<workspace_name>-uc-cluster`. Confirm the **Policy** field is `Personal Compute`, access mode is **Single user**, runtime is the latest LTS, node type matches `var.node_type_id`, auto-termination matches `var.autotermination_minutes` (default `10`), and the cluster carries the `ClusterType = TerraformDeploymentTesting` tag. Start the cluster and wait for "Running".
+4. **Single-node cluster** – Under **Compute**, locate the cluster named `<workspace_name>-uc-cluster`. Confirm the **Policy** field is `Personal Compute`, access mode matches `var.data_security_mode` (default **Single user**), runtime is the latest LTS, node type matches `var.node_type_id`, auto-termination matches `var.autotermination_minutes` (default `10`), and the cluster carries the `ClusterType = TerraformDeploymentTesting` tag. Start the cluster and wait for "Running".
 
 ## Clean-up
 

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/cluster.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/cluster.tf
@@ -26,8 +26,8 @@ resource "databricks_cluster" "uc_single_node" {
   policy_id               = data.databricks_cluster_policy.personal.id
   spark_version           = data.databricks_spark_version.latest_lts.id
   node_type_id            = var.node_type_id
-  autotermination_minutes = var.autotermination_minutes
-  data_security_mode      = var.data_security_mode
+  autotermination_minutes = var.cluster_autotermination_minutes
+  data_security_mode      = "SINGLE_USER"
   single_user_name        = var.admin_user
 
   custom_tags = {

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/cluster.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/cluster.tf
@@ -2,12 +2,22 @@
 data "databricks_spark_version" "latest_lts" {
   long_term_support = true
   latest            = true
+
+  depends_on = [
+    databricks_metastore_assignment.this,
+    databricks_mws_permission_assignment.workspace_access,
+  ]
 }
 
 // Built-in Personal Compute policy enforces SINGLE_USER access mode, the
 // single-node cluster profile, and other UC-compatible defaults.
 data "databricks_cluster_policy" "personal" {
   name = "Personal Compute"
+
+  depends_on = [
+    databricks_metastore_assignment.this,
+    databricks_mws_permission_assignment.workspace_access,
+  ]
 }
 
 // UC-compatible single-node cluster governed by the Personal Compute policy.
@@ -17,6 +27,8 @@ resource "databricks_cluster" "uc_single_node" {
   spark_version           = data.databricks_spark_version.latest_lts.id
   node_type_id            = var.node_type_id
   autotermination_minutes = var.autotermination_minutes
+  data_security_mode      = var.data_security_mode
+  single_user_name        = var.admin_user
 
   custom_tags = {
     "ClusterType" = "TerraformDeploymentTesting"

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/cluster.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/cluster.tf
@@ -1,0 +1,29 @@
+// Latest LTS Databricks Runtime.
+data "databricks_spark_version" "latest_lts" {
+  long_term_support = true
+  latest            = true
+}
+
+// Built-in Personal Compute policy enforces SINGLE_USER access mode, the
+// single-node cluster profile, and other UC-compatible defaults.
+data "databricks_cluster_policy" "personal" {
+  name = "Personal Compute"
+}
+
+// UC-compatible single-node cluster governed by the Personal Compute policy.
+resource "databricks_cluster" "uc_single_node" {
+  cluster_name            = "${var.workspace_name}-uc-cluster"
+  policy_id               = data.databricks_cluster_policy.personal.id
+  spark_version           = data.databricks_spark_version.latest_lts.id
+  node_type_id            = var.node_type_id
+  autotermination_minutes = var.autotermination_minutes
+
+  custom_tags = {
+    "ClusterType" = "TerraformDeploymentTesting"
+  }
+
+  depends_on = [
+    databricks_metastore_assignment.this,
+    databricks_mws_permission_assignment.workspace_access,
+  ]
+}

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/outputs.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/outputs.tf
@@ -12,6 +12,11 @@ output "workspace_url" {
   value       = "https://${azurerm_databricks_workspace.this.workspace_url}/"
 }
 
+output "cluster_id" {
+  description = "ID of the UC-compatible single-node cluster"
+  value       = databricks_cluster.uc_single_node.id
+}
+
 # =============================================================================
 # Network Outputs
 # =============================================================================

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/terraform.tfvars.example
@@ -25,6 +25,8 @@ uc_storage_account_name = "ucrootstorage"
 catalog_name            = "my-catalog"
 storage_credential_name = "my-uc-storage-cred"
 external_location_name = "my-ext-loc"
+node_type_id = "Standard_DS3_v2"
+cluster_autotermination_minutes = "10"
 
 # =============================================================================
 # Network Configuration

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/terraform.tfvars.example
@@ -20,11 +20,14 @@ location = "westeurope"
 databricks_account_id = "xxx-xxx"
 existing_metastore_id = "xxx-xxx"
 new_metastore_name = ""
-managed_resource_group_name = null #optional. if no name is provided, azure will generate one on it's own
+managed_resource_group_name = null # optional. If no name is provided, azure will generate one on it's own
 uc_storage_account_name = "ucrootstorage"
 catalog_name            = "my-catalog"
 storage_credential_name = "my-uc-storage-cred"
 external_location_name = "my-ext-loc"
+node_type_id = "Standard_DS3_v2" # optional. Override for a larger driver
+autotermination_minutes = 10     # optional. Minimum 10
+
 # =============================================================================
 # Network Configuration
 # =============================================================================

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/terraform.tfvars.example
@@ -25,8 +25,6 @@ uc_storage_account_name = "ucrootstorage"
 catalog_name            = "my-catalog"
 storage_credential_name = "my-uc-storage-cred"
 external_location_name = "my-ext-loc"
-node_type_id = "Standard_DS3_v2" # optional. Override for a larger driver
-autotermination_minutes = 10     # optional. Minimum 10
 
 # =============================================================================
 # Network Configuration

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/variables.tf
@@ -139,6 +139,16 @@ variable "autotermination_minutes" {
   }
 }
 
+variable "data_security_mode" {
+  description = "Access mode for the UC-compatible single-node cluster. SINGLE_USER is required for UC workloads with the Personal Compute policy."
+  type        = string
+  default     = "SINGLE_USER"
+  validation {
+    condition     = contains(["SINGLE_USER", "USER_ISOLATION", "NONE", "LEGACY_TABLE_ACL", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD"], var.data_security_mode)
+    error_message = "data_security_mode must be one of: SINGLE_USER, USER_ISOLATION, NONE, LEGACY_TABLE_ACL, LEGACY_PASSTHROUGH, LEGACY_SINGLE_USER, LEGACY_SINGLE_USER_STANDARD."
+  }
+}
+
 # =============================================================================
 # Network Configuration
 # =============================================================================

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/variables.tf
@@ -129,23 +129,13 @@ variable "node_type_id" {
   default     = "Standard_DS3_v2"
 }
 
-variable "autotermination_minutes" {
+variable "cluster_autotermination_minutes" {
   description = "Idle minutes before the single-node UC cluster auto-terminates."
   type        = number
   default     = 10
   validation {
-    condition     = var.autotermination_minutes >= 10
-    error_message = "autotermination_minutes must be at least 10 (Databricks minimum for auto-termination)."
-  }
-}
-
-variable "data_security_mode" {
-  description = "Access mode for the UC-compatible single-node cluster. SINGLE_USER is required for UC workloads with the Personal Compute policy."
-  type        = string
-  default     = "SINGLE_USER"
-  validation {
-    condition     = contains(["SINGLE_USER", "USER_ISOLATION", "NONE", "LEGACY_TABLE_ACL", "LEGACY_PASSTHROUGH", "LEGACY_SINGLE_USER", "LEGACY_SINGLE_USER_STANDARD"], var.data_security_mode)
-    error_message = "data_security_mode must be one of: SINGLE_USER, USER_ISOLATION, NONE, LEGACY_TABLE_ACL, LEGACY_PASSTHROUGH, LEGACY_SINGLE_USER, LEGACY_SINGLE_USER_STANDARD."
+    condition     = var.cluster_autotermination_minutes >= 10
+    error_message = "cluster_autotermination_minutes must be at least 10 (Databricks minimum for auto-termination)."
   }
 }
 

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/variables.tf
@@ -123,6 +123,22 @@ variable "new_metastore_name" {
   }
 }
 
+variable "node_type_id" {
+  description = "Azure VM SKU for the single-node UC cluster driver."
+  type        = string
+  default     = "Standard_DS3_v2"
+}
+
+variable "autotermination_minutes" {
+  description = "Idle minutes before the single-node UC cluster auto-terminates."
+  type        = number
+  default     = 10
+  validation {
+    condition     = var.autotermination_minutes >= 10
+    error_message = "autotermination_minutes must be at least 10 (Databricks minimum for auto-termination)."
+  }
+}
+
 # =============================================================================
 # Network Configuration
 # =============================================================================


### PR DESCRIPTION
# Pull Request

## Description
Adds a UC-compatible single-node cluster to the azure-vnet-injection-uc Terraform example. Cluster runs on the latest LTS runtime under the built-in Personal Compute policy (Single User, single-node, UC-safe defaults), with configurable node type and auto-termination. 

## Category
- [ ] core-platform
- [ ] data-engineering
- [ ] data-governance
- [ ] data-warehousing
- [ ] genai-ml
- [ ] launch-accelerator
- [x] workspace-setup

## Type of Change
- [ ] New project
- [ ] Bug fix
- [x] Enhancement
- [ ] Documentation

## Project Details
**Project Name:** azure-vnet-injection-uc
**Purpose:** Provision a working UC-compatible cluster as part of the example, removing the manual cluster-creation validation step.
**Technologies Used:** Terraform, azurerm, databricks provider, Azure (VNet, NSG, NAT GW, Storage), Databricks Unity Catalog

## Testing
- [x] Code runs without errors
- [x] Documentation is complete
- [x] Used only synthetic data

## Security Compliance ✅
- [x] No customer data, PII, or proprietary information
- [x] No credentials or access tokens
- [x] Only synthetic data used
- [x] Third-party licenses acknowledged

---

**By submitting this PR, I confirm I have followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and security requirements.**
