### PR TITLE
AWS Workspace Setup with a user-defined catalog

### DIFF
--- a/workspace-setup/terraform-examples/README.md
+++ b/workspace-setup/terraform-examples/README.md
@@ -70,6 +70,7 @@ This naming helps you quickly identify the right scenario for your needs.
 | Scenario | Description |
 |----------|-------------|
 | [aws-byovpc](./aws/aws-byovpc/) | Deploy a Databricks workspace using "Bring Your Own VPC" (BYOVPC) pattern with Unity Catalog Metastore. Create a new VPC or use an existing one with full control over network infrastructure. |
+| [aws-byovpc-uc](./aws/aws-byovpc-uc/) | Deploy a Databricks workspace using "Bring Your Own VPC" (BYOVPC) with Unity Catalog metastore, external location, and user-defined catalog backed by dedicated S3. Creates a new VPC from scratch with full control over network infrastructure (existing VPC not supported). |
 | [aws-byovpc-classic-privatelink](./aws/aws-byovpc-classic-privatelink/) | Deploy a Databricks workspace with classic Private Link (REST API and SCC relay). Choose **standard** (template creates VPC with NAT/IGW and S3/STS/Kinesis endpoints), **fully_private** (no NAT/IGW, dedicated endpoint subnet), or **custom** (you supply VPC, subnets, security groups, and backend VPC endpoint IDs; no AWS networking created). Optional Unity Catalog metastore creation or attachment. |
 
 ### Azure

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/.gitignore
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/.gitignore
@@ -1,0 +1,42 @@
+# Local .terraform directories
+*/.terraform/*
+*/.terraform
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore .tfvars files that contain secrets
+# Keep .tfvars.example as template
+terraform.tfvars
+*auto.tfvars
+*.auto.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# MAC Control
+.DS_Store
+
+# IntelliJ
+.idea/

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/README.md
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/README.md
@@ -1,11 +1,11 @@
-# AWS BYOVPC with Default Catalog Workspace Setup Guide
+# AWS BYOVPC with User-Defined Catalog Workspace Setup Guide
 
-This Terraform example deploys a Databricks workspace on AWS using the "Bring Your Own VPC" (BYOVPC) pattern with Unity Catalog and a default catalog backed by an external location. It provisions the full networking stack (VPC, subnets, NAT Gateway, VPC endpoints, security groups), a cross-account IAM role, an S3 root storage bucket, a Databricks workspace, and configures Unity Catalog with a storage credential, external location, and default catalog backed by a dedicated S3 bucket.
+This Terraform example deploys a Databricks workspace on AWS using the "Bring Your Own VPC" (BYOVPC) pattern with Unity Catalog and a user-defined catalog backed by an external location. It provisions the full networking stack (VPC, subnets, NAT Gateway, VPC endpoints, security groups), a cross-account IAM role, an S3 root storage bucket, a Databricks workspace, and configures Unity Catalog with a storage credential, external location, and user-defined catalog backed by a dedicated S3 bucket.
 
 It is important to note that this deployment creates a new VPC from scratch and currently does not support using an existing VPC.
 
 ### Important
-The difference between this deployment option and the standard option for aws-byovpc is the inclusion of a default catalog and external location. The requirements and authentication procedures remain the same.
+The difference between this deployment option and the standard option for aws-byovpc is the inclusion of a user-defined catalog and external location. The requirements and authentication procedures remain the same.
 
 ## Requirements
 
@@ -15,6 +15,7 @@ The difference between this deployment option and the standard option for aws-by
 - Databricks account created (E2 account)
 - Databricks account admin access
 - AWS permissions to create VPC, IAM, S3, and Security Group resources
+- When using an existing metastore (i.e. `metastore_id` is set), the identity used by Terraform (typically the Databricks **service principal** configured via `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`) must be able to create external locations on that metastore (for example `CREATE EXTERNAL LOCATION` on the metastore, or equivalent metastore-level permissions your organization grants). Metastores created by this template configure admin principals as part of this flow; attaching to an existing metastore often requires an account admin to grant this explicitly.
 
 ## Before you begin
 
@@ -74,7 +75,7 @@ The code provisions:
 8. **Unity Catalog metastore** -- Either creates a new metastore (when `metastore_id` is empty) or uses an existing one. The metastore is assigned to the workspace.
 9. **Unity Catalog IAM role and S3 bucket** -- A dedicated IAM role and S3 bucket for the Unity Catalog external location, with appropriate trust and access policies.
 10. **Storage credential and external location** -- A Unity Catalog storage credential backed by the IAM role, and an external location pointing to the catalog S3 bucket.
-11. **Default catalog** -- A Unity Catalog catalog backed by the external location's storage.
+11. **User-defined catalog** -- A Unity Catalog catalog backed by the external location's storage.
 
 ### Variables
 
@@ -100,6 +101,11 @@ Copy `terraform.tfvars.example` to `terraform.tfvars` in the `tf/` directory and
 | `aws_account_id` | **(Required)** AWS account ID where resources are deployed (used to construct IAM role ARNs for Unity Catalog). |
 | `metastore_id` | **(Optional)** Existing Unity Catalog metastore ID. Leave empty to create a new one. Default: `""`. |
 | `metastore_name` | **(Optional)** Name for the Unity Catalog metastore. Required when `metastore_id` is empty. Default: `""`. |
+| `catalog_name` | **(Optional)** Unity Catalog catalog name. Default `""` uses `prefix`. |
+| `external_location_name` | **(Optional)** Unity Catalog external location name. Default `""` uses `{resource_prefix}-external-location`. |
+| `storage_credential_name` | **(Optional)** Unity Catalog storage credential name. Default `""` uses `{resource_prefix}-storage-credential`. |
+
+**Note:** Those three variables default to `""` in `variables.tf`. They cannot default to `prefix` or `resource_prefix` there because Terraform does not allow a variable `default` to reference another variable; fallbacks are applied in `locals` in `unity_catalog.tf`.
 
 ## Deploy
 
@@ -179,7 +185,7 @@ tf/
 ├── credential.tf               # IAM cross-account role and policies
 ├── root_s3_bucket.tf           # S3 bucket for workspace root storage
 ├── metastore.tf                # Unity Catalog metastore
-├── unity_catalog.tf            # Storage credential, external location, and default catalog
+├── unity_catalog.tf            # Storage credential, external location, and user-defined catalog
 ```
 
 | File | Purpose |
@@ -194,8 +200,8 @@ tf/
 | **credential.tf** | Cross-account IAM role and policy for Databricks workspace provisioning. |
 | **root_s3_bucket.tf** | S3 bucket for workspace root storage (DBFS) with Databricks bucket policy. |
 | **metastore.tf** | Unity Catalog metastore (create new or use existing) and workspace assignment. |
-| **unity_catalog.tf** | Unity Catalog IAM role, S3 bucket, storage credential, external location, and default catalog. |
-| **outputs.tf** | Workspace URL/ID; VPC ID; subnet IDs; NAT gateway IDs; security group ID; S3 bucket names; metastore ID; credentials and network config IDs. |
+| **unity_catalog.tf** | Unity Catalog IAM role, S3 bucket, storage credential, external location, and user-defined catalog. |
+| **outputs.tf** | Workspace URL/ID; VPC ID; subnet IDs; NAT gateway IDs; security group ID; S3 bucket names; metastore ID; Unity Catalog catalog, external location, and storage credential names; credentials and network config IDs. |
 
 **Note:** There is no `main.tf` file in this project. Instead, resources are organized into descriptive, purpose-specific files.
 

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/README.md
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/README.md
@@ -166,7 +166,7 @@ Type `yes` when prompted. Destruction can take several minutes.
 | `terraform plan` fails on permissions | Insufficient AWS IAM permissions | Ensure the identity has permissions to create VPC, IAM, S3, and Security Group resources. |
 | Subnet CIDR errors | CIDRs overlap or don't fit in VPC range | Ensure `private_subnets_cidr`, `public_subnets_cidr`, and `intra_subnet_cidr` are non-overlapping and within `vpc_cidr_range`. |
 | NAT Gateway or outbound connectivity issues | Cluster nodes cannot reach the control plane | Verify the NAT Gateway exists and has a public IP. Check that security group rules allow outbound traffic on required ports. |
-| Cannot delete catalog on destroy | Catalog is not empty | Ensure `force_destroy = true` is set on the `databricks_catalog` and `databricks_external_location` resources, then run `terraform apply -target=databricks_catalog.uc_quickstart` before destroying. |
+| Cannot delete catalog on destroy | Catalog still has schemas, tables, or volumes | This template already sets `force_destroy = true` on `databricks_catalog.uc_quickstart` and `databricks_external_location`, so a normal `terraform destroy` should remove them. If destroy fails, empty or drop objects in that catalog in the workspace, then run `terraform destroy` again. 
 
 ## File Structure
 
@@ -199,7 +199,7 @@ tf/
 | **security_group.tf** | Default security group egress rules for Databricks-required ports, internal TCP/UDP egress, and self-ingress. |
 | **credential.tf** | Cross-account IAM role and policy for Databricks workspace provisioning. |
 | **root_s3_bucket.tf** | S3 bucket for workspace root storage (DBFS) with Databricks bucket policy. |
-| **metastore.tf** | Unity Catalog metastore (create new or use existing) and workspace assignment. |
+| **metastore.tf** | Unity Catalog metastore (create new or use existing), region check for existing metastores, and workspace assignment. |
 | **unity_catalog.tf** | Unity Catalog IAM role, S3 bucket, storage credential, external location, and user-defined catalog. |
 | **outputs.tf** | Workspace URL/ID; VPC ID; subnet IDs; NAT gateway IDs; security group ID; S3 bucket names; metastore ID; Unity Catalog catalog, external location, and storage credential names; credentials and network config IDs. |
 

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/README.md
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/README.md
@@ -1,0 +1,213 @@
+# AWS BYOVPC with Default Catalog Workspace Setup Guide
+
+This Terraform example deploys a Databricks workspace on AWS using the "Bring Your Own VPC" (BYOVPC) pattern with Unity Catalog and a default catalog backed by an external location. It provisions the full networking stack (VPC, subnets, NAT Gateway, VPC endpoints, security groups), a cross-account IAM role, an S3 root storage bucket, a Databricks workspace, and configures Unity Catalog with a storage credential, external location, and default catalog backed by a dedicated S3 bucket.
+
+It is important to note that this deployment creates a new VPC from scratch and currently does not support using an existing VPC.
+
+### Important
+The difference between this deployment option and the standard option for aws-byovpc is the inclusion of a default catalog and external location. The requirements and authentication procedures remain the same.
+
+## Requirements
+
+- Terraform is installed on your local machine (version ~> 1.3): [link](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli#install-terraform)
+- AWS CLI is installed on your local machine: [Mac](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) or [Windows](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- AWS CLI configured with appropriate credentials
+- Databricks account created (E2 account)
+- Databricks account admin access
+- AWS permissions to create VPC, IAM, S3, and Security Group resources
+
+## Before you begin
+
+Configuration values (Databricks account ID, AWS region, VPC and subnet CIDRs, availability zones, metastore options) are defined as variables. Copy `tf/terraform.tfvars.example` to `tf/terraform.tfvars` and set your values there. Terraform loads `terraform.tfvars` automatically. You can also use a file ending in `.auto.tfvars` or pass variables via the command line.
+
+## Authenticate
+
+### AWS Authentication
+
+#### Option 1: Environment variables (for users)
+
+```sh
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_SESSION_TOKEN="your-session-token"  # If using temporary credentials
+```
+
+#### Option 2: AWS CLI profile
+
+```sh
+export AWS_PROFILE="your-profile"
+```
+
+#### Option 3: AWS SSO login (for users)
+
+```sh
+aws sso login --profile your-profile
+```
+
+### Databricks Authentication
+
+Use a service principal for account-level operations:
+
+```sh
+export DATABRICKS_CLIENT_ID="your-client-id"
+export DATABRICKS_CLIENT_SECRET="your-client-secret"
+```
+
+For more information on creating a Databricks service principal, visit the [Databricks documentation](https://docs.databricks.com/en/dev-tools/service-principals.html).
+
+## What this Terraform code does
+
+### Overview
+
+The code provisions:
+
+1. **VPC** -- A VPC with address space from `vpc_cidr_range`, containing three subnet types:
+   - **Private subnets** -- CIDRs from `private_subnets_cidr`. Used by Databricks for cluster nodes.
+   - **Public subnets** -- CIDRs from `public_subnets_cidr`. Used for the NAT Gateway and internet gateway.
+   - **Intra subnets** -- CIDRs from `intra_subnet_cidr`. Used for VPC endpoints (STS, Kinesis).
+2. **NAT Gateway** -- A single NAT Gateway for outbound internet connectivity from private subnets.
+3. **VPC Endpoints** -- Gateway endpoint for S3 and interface endpoints for STS and Kinesis Streams.
+4. **Security group** -- Default VPC security group configured with Databricks-required egress rules (ports 443, 3306, 2443, 8443-8451), internal TCP/UDP egress, and self-ingress. Optionally, you can provide existing security group IDs via `security_group_ids`.
+5. **Cross-account IAM role** -- An IAM role that grants Databricks access to your AWS account for workspace provisioning.
+6. **Root S3 bucket** -- An S3 bucket for workspace root storage (DBFS), with a Databricks-specific bucket policy.
+7. **Databricks workspace** -- An E2 workspace using the provisioned network, credentials, and storage configuration.
+8. **Unity Catalog metastore** -- Either creates a new metastore (when `metastore_id` is empty) or uses an existing one. The metastore is assigned to the workspace.
+9. **Unity Catalog IAM role and S3 bucket** -- A dedicated IAM role and S3 bucket for the Unity Catalog external location, with appropriate trust and access policies.
+10. **Storage credential and external location** -- A Unity Catalog storage credential backed by the IAM role, and an external location pointing to the catalog S3 bucket.
+11. **Default catalog** -- A Unity Catalog catalog backed by the external location's storage.
+
+### Variables
+
+Copy `terraform.tfvars.example` to `terraform.tfvars` in the `tf/` directory and set your values. Do not commit `terraform.tfvars` (it may contain sensitive data). Terraform automatically loads `terraform.tfvars`; for other file names use `-var-file`.
+
+#### List of variables
+
+| Variable | Description |
+|----------|-------------|
+| `databricks_account_id` | **(Required)** ID of the Databricks account. |
+| `prefix` | **(Optional)** Prefix for Databricks resource names (workspace name, storage config, etc.). Default: `databricks-workspace`. |
+| `resource_prefix` | **(Optional)** Prefix for naming AWS resources (VPC, S3, IAM, etc.). Lowercase letters, numbers, hyphens, and dots only, max 40 characters. Default: `databricks-workspace`. |
+| `pricing_tier` | **(Optional)** Pricing tier for the workspace. `ENTERPRISE` or `PREMIUM`. Default: `PREMIUM`. |
+| `region` | **(Required)** AWS region code where resources will be deployed. Must be a [Databricks-supported region](https://docs.databricks.com/en/resources/supported-regions.html). |
+| `tags` | **(Optional)** Additional tags to apply to all AWS resources. Default: `{}`. |
+| `vpc_cidr_range` | **(Optional)** CIDR range for the VPC. Default: `10.0.0.0/16`. |
+| `availability_zones` | **(Required)** List of AWS availability zones for subnet distribution (e.g. `["us-west-2a", "us-west-2b"]`). |
+| `private_subnets_cidr` | **(Required)** List of private subnet CIDR blocks (one per AZ). |
+| `public_subnets_cidr` | **(Required)** List of public subnet CIDR blocks (one per AZ). |
+| `intra_subnet_cidr` | **(Required)** List of intra subnet CIDR blocks for VPC endpoints. |
+| `security_group_ids` | **(Optional)** Existing security group IDs to use. If empty, the VPC default security group is used. Default: `[]`. |
+| `sg_egress_ports` | **(Optional)** List of egress ports to allow in security group rules. Default: `[443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]`. |
+| `aws_account_id` | **(Required)** AWS account ID where resources are deployed (used to construct IAM role ARNs for Unity Catalog). |
+| `metastore_id` | **(Optional)** Existing Unity Catalog metastore ID. Leave empty to create a new one. Default: `""`. |
+| `metastore_name` | **(Optional)** Name for the Unity Catalog metastore. Required when `metastore_id` is empty. Default: `""`. |
+
+## Deploy
+
+```bash
+cd tf/
+
+# Initialize Terraform
+terraform init
+
+# Review the execution plan
+terraform plan
+
+# Apply the configuration
+terraform apply
+```
+
+Occasionally, you'll be asked to confirm certain actions; type yes when prompted. The deployment typically takes 10-15 minutes. Once the execution finishes, the terminal will output the URL of the created workspace.
+
+## Access Your Workspace
+
+After successful deployment:
+```bash
+# Get the workspace URL
+terraform output workspace_url
+
+# Get the workspace ID
+terraform output workspace_id
+```
+
+Navigate to the workspace URL and log in with your Databricks credentials.
+
+## Validation
+
+To verify the deployment succeeded:
+
+1. **Terraform outputs** -- From the `tf/` directory, run `terraform output` and confirm `workspace_url`, `workspace_id`, `vpc_id`, and `metastore_id` are present and non-empty.
+2. **AWS console** -- In your account, check that the VPC, subnets, NAT Gateway, S3 buckets, and IAM roles exist and are in a healthy state.
+3. **Workspace access** -- Open `terraform output -raw workspace_url` in a browser and sign in.
+4. **Classic cluster** -- Create and start a **classic cluster** (Compute > Create cluster; use the default cluster type). Once the cluster is in "Running" state, the setup is proven.
+
+## Clean-up
+
+To destroy all resources created by this scenario:
+
+```bash
+cd tf
+terraform destroy
+```
+
+Type `yes` when prompted. Destruction can take several minutes.
+
+## Troubleshooting
+
+| Issue | Possible cause | Solution |
+|-------|----------------|----------|
+| AWS provider auth fails | AWS CLI not configured or credentials expired | Run `aws configure` or set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` environment variables. |
+| Databricks provider auth fails | Missing or invalid service principal credentials | Set `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` environment variables. |
+| `terraform plan` fails on permissions | Insufficient AWS IAM permissions | Ensure the identity has permissions to create VPC, IAM, S3, and Security Group resources. |
+| Subnet CIDR errors | CIDRs overlap or don't fit in VPC range | Ensure `private_subnets_cidr`, `public_subnets_cidr`, and `intra_subnet_cidr` are non-overlapping and within `vpc_cidr_range`. |
+| NAT Gateway or outbound connectivity issues | Cluster nodes cannot reach the control plane | Verify the NAT Gateway exists and has a public IP. Check that security group rules allow outbound traffic on required ports. |
+| Cannot delete catalog on destroy | Catalog is not empty | Ensure `force_destroy = true` is set on the `databricks_catalog` and `databricks_external_location` resources, then run `terraform apply -target=databricks_catalog.uc_quickstart` before destroying. |
+
+## File Structure
+
+This project uses a flat, organized structure with purpose-specific files instead of a monolithic `main.tf`:
+
+```
+tf/
+├── versions.tf                 # Terraform and provider version constraints
+├── providers.tf                # Provider configurations (AWS, Databricks)
+├── variables.tf                # All input variable definitions
+├── outputs.tf                  # All output values
+├── terraform.tfvars.example    # Configuration template
+├── workspace.tf                # Databricks workspace and MWS resources
+├── network.tf                  # VPC, subnets, and VPC endpoints
+├── security_group.tf           # Security group rules
+├── credential.tf               # IAM cross-account role and policies
+├── root_s3_bucket.tf           # S3 bucket for workspace root storage
+├── metastore.tf                # Unity Catalog metastore
+├── unity_catalog.tf            # Storage credential, external location, and default catalog
+```
+
+| File | Purpose |
+|------|---------|
+| **versions.tf** | Terraform and provider version constraints (aws, databricks, random, time, null). |
+| **providers.tf** | AWS provider (region-based) and Databricks providers (account-level via MWS endpoint, workspace-level via workspace URL). Auth via environment variables. |
+| **variables.tf** | Input variables (Databricks config, AWS config, network CIDRs, security group options, metastore options) with validation. |
+| **terraform.tfvars.example** | Example variable values; copy to `terraform.tfvars` and set your account ID, region, CIDRs, etc. |
+| **workspace.tf** | Databricks MWS resources: storage configuration, credentials, network configuration, and workspace. |
+| **network.tf** | VPC module (address space, public/private/intra subnets, NAT Gateway, IGW) and VPC endpoints (S3 gateway, STS and Kinesis interface endpoints). |
+| **security_group.tf** | Default security group egress rules for Databricks-required ports, internal TCP/UDP egress, and self-ingress. |
+| **credential.tf** | Cross-account IAM role and policy for Databricks workspace provisioning. |
+| **root_s3_bucket.tf** | S3 bucket for workspace root storage (DBFS) with Databricks bucket policy. |
+| **metastore.tf** | Unity Catalog metastore (create new or use existing) and workspace assignment. |
+| **unity_catalog.tf** | Unity Catalog IAM role, S3 bucket, storage credential, external location, and default catalog. |
+| **outputs.tf** | Workspace URL/ID; VPC ID; subnet IDs; NAT gateway IDs; security group ID; S3 bucket names; metastore ID; credentials and network config IDs. |
+
+**Note:** There is no `main.tf` file in this project. Instead, resources are organized into descriptive, purpose-specific files.
+
+Terraform will automatically load all `.tf` files in the directory, so the absence of `main.tf` doesn't affect functionality.
+
+
+## Terraform template examples and more documentation:
+
+Keep in mind that the git code is not always up to date. You should use these templates as an example and not directly copy and paste. Please note that the code in the template projects is provided for your exploration only and is not formally supported by Databricks with Service Level Agreements (SLAs). They are provided AS-IS, and we do not make any guarantees of any kind.
+
+- [Databricks on AWS Configuration](https://github.com/databricks/terraform-databricks-examples/tree/main/examples/aws-databricks-flat)
+- [Security Reference Architecture Template](https://github.com/databricks/terraform-databricks-sra/tree/main/aws)
+    - This is a template that adheres to the best security practices we recommend.
+- [Terraform Databricks provider documentation](https://registry.terraform.io/providers/databricks/databricks/latest/docs)
+- [Databricks on AWS networking](https://docs.databricks.com/en/security/network/classic/customer-managed-vpc.html)

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/.terraform.lock.hcl
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/.terraform.lock.hcl
@@ -1,0 +1,99 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/databricks/databricks" {
+  version     = "1.114.2"
+  constraints = "~> 1.84"
+  hashes = [
+    "h1:E4sES+/XDGraAaCQD4IszT/MH2T/Yl0AMWK36Z01JTI=",
+    "zh:3d0ac21a1f29783731591bf3a6f6c7d2f4171e24d5dafcfade982722fa1ed0d3",
+    "zh:608a9b68172a08141d22e430434b2580a0a50d76e86dffcf6767f7115ddf6e80",
+    "zh:8f6b306616960e9f42d7575eda17ad8b9d7d93876b6ea56432a23e6a6d3f7612",
+    "zh:a3fd2adcfc24b8330f6422277a865e93bce661e8d1e5f39963f22cabe4053807",
+    "zh:d5b2403712039e8322f68b5c55c42aaecbdca61db948a3ee520a87f36d9fc220",
+    "zh:faebc71a9546650dcae547dc564e974c914bf46ab5f2f83ca4dfff20bf6b5025",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = ">= 5.0.0, >= 5.76.0, < 7.0.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = "~> 0.9"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/credential.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/credential.tf
@@ -1,0 +1,22 @@
+data "databricks_aws_assume_role_policy" "this" {
+  provider    = databricks.mws
+  external_id = var.databricks_account_id
+}
+
+resource "aws_iam_role" "cross_account_role" {
+  name               = "${var.prefix}-crossaccount"
+  assume_role_policy = data.databricks_aws_assume_role_policy.this.json
+  tags               = var.tags
+}
+
+data "databricks_aws_crossaccount_policy" "this" {
+  provider    = databricks.mws
+  policy_type = "customer"
+}
+
+resource "aws_iam_role_policy" "this" {
+  name   = "${var.prefix}-policy"
+  role   = aws_iam_role.cross_account_role.id
+  policy = data.databricks_aws_crossaccount_policy.this.json
+}
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/metastore.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/metastore.tf
@@ -1,0 +1,16 @@
+resource "databricks_metastore" "metastore" {
+  count         = var.metastore_id == "" ? 1 : 0
+  provider      = databricks.mws
+  name          = var.metastore_name
+  region        = var.region
+  force_destroy = true # This is required to destroy the metastore if it has catalogs and workspaces attached to it
+}
+
+resource "databricks_metastore_assignment" "this" {
+  metastore_id = var.metastore_id == "" ? databricks_metastore.metastore[0].id : var.metastore_id
+  provider     = databricks.mws
+  workspace_id = databricks_mws_workspaces.this.workspace_id
+  depends_on   = [databricks_mws_workspaces.this, time_sleep.wait_2_minutes]
+}
+
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/metastore.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/metastore.tf
@@ -1,3 +1,9 @@
+data "databricks_metastore" "existing" {
+  count        = var.metastore_id != "" ? 1 : 0
+  provider     = databricks.mws
+  metastore_id = var.metastore_id
+}
+
 resource "databricks_metastore" "metastore" {
   count         = var.metastore_id == "" ? 1 : 0
   provider      = databricks.mws
@@ -10,7 +16,12 @@ resource "databricks_metastore_assignment" "this" {
   metastore_id = var.metastore_id == "" ? databricks_metastore.metastore[0].id : var.metastore_id
   provider     = databricks.mws
   workspace_id = databricks_mws_workspaces.this.workspace_id
-  depends_on   = [databricks_mws_workspaces.this, time_sleep.wait_2_minutes]
+  depends_on   = [data.databricks_metastore.existing, databricks_mws_workspaces.this, time_sleep.wait_2_minutes]
+
+  lifecycle {
+    precondition {
+      condition     = var.metastore_id == "" ? true : data.databricks_metastore.existing[0].region == var.region
+      error_message = "Workspace region should match metastore region."
+    }
+  }
 }
-
-

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/network.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/network.tf
@@ -39,7 +39,7 @@ module "vpc_endpoints" {
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   version = "5.1.1"
 
-  vpc_id             = module.vpc.vpc_id
+  vpc_id = module.vpc.vpc_id
 
   endpoints = {
     s3 = {

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/network.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/network.tf
@@ -1,0 +1,74 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.1.1"
+
+  name = "${var.resource_prefix}-classic-compute-plane-vpc"
+  cidr = var.vpc_cidr_range
+  azs  = var.availability_zones
+
+  enable_dns_hostnames   = true
+  enable_nat_gateway     = true
+  single_nat_gateway     = true
+  one_nat_gateway_per_az = false
+  create_igw             = true
+
+  private_subnet_names = [for az in var.availability_zones : format("%s-private-%s", var.resource_prefix, az)]
+  private_subnets      = var.private_subnets_cidr
+
+  public_subnet_names = [for az in var.availability_zones : format("%s-public-%s", var.resource_prefix, az)]
+  public_subnets      = var.public_subnets_cidr
+
+  intra_subnet_names = [for az in var.availability_zones : format("%s-intra-%s", var.resource_prefix, az)]
+  intra_subnets      = var.intra_subnet_cidr
+
+  # Enable default security group management
+  manage_default_security_group  = true
+  default_security_group_name    = "${var.resource_prefix}-default-sg"
+  default_security_group_ingress = []
+  default_security_group_egress  = []
+
+  tags = merge(
+    var.tags,
+    {
+      Project = var.resource_prefix
+    }
+  )
+}
+
+module "vpc_endpoints" {
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "5.1.1"
+
+  vpc_id             = module.vpc.vpc_id
+
+  endpoints = {
+    s3 = {
+      service         = "s3"
+      service_type    = "Gateway"
+      route_table_ids = module.vpc.private_route_table_ids
+      tags = {
+        Name    = "${var.resource_prefix}-s3-vpc-endpoint"
+        Project = var.resource_prefix
+      }
+    },
+    sts = {
+      service             = "sts"
+      private_dns_enabled = true
+      subnet_ids          = module.vpc.intra_subnets
+      tags = {
+        Name    = "${var.resource_prefix}-sts-vpc-endpoint"
+        Project = var.resource_prefix
+      }
+    },
+    kinesis-streams = {
+      service             = "kinesis-streams"
+      private_dns_enabled = true
+      subnet_ids          = module.vpc.intra_subnets
+      tags = {
+        Name    = "${var.resource_prefix}-kinesis-vpc-endpoint"
+        Project = var.resource_prefix
+      }
+    }
+  }
+}
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/outputs.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/outputs.tf
@@ -99,6 +99,11 @@ output "external_location_url" {
   value       = databricks_external_location.uc_external_location.url
 }
 
+output "storage_credential_name" {
+  description = "Name of the Unity Catalog storage credential"
+  value       = databricks_storage_credential.uc_storage_cred.name
+}
+
 # =============================================================================
 # Databricks Account Objects Outputs
 # =============================================================================

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/outputs.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/outputs.tf
@@ -85,7 +85,7 @@ output "metastore_name" {
 }
 
 output "catalog_name" {
-  description = "Name of the default Unity Catalog catalog"
+  description = "Name of the user-defined Unity Catalog catalog"
   value       = databricks_catalog.uc_quickstart.name
 }
 

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/outputs.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/outputs.tf
@@ -1,0 +1,120 @@
+# =============================================================================
+# Databricks Workspace Outputs
+# =============================================================================
+
+output "workspace_id" {
+  description = "ID of the Databricks workspace"
+  value       = databricks_mws_workspaces.this.workspace_id
+}
+
+output "workspace_url" {
+  description = "URL of the Databricks workspace"
+  value       = databricks_mws_workspaces.this.workspace_url
+}
+
+output "workspace_name" {
+  description = "Name of the Databricks workspace"
+  value       = databricks_mws_workspaces.this.workspace_name
+}
+
+output "workspace_status" {
+  description = "Status of the Databricks workspace"
+  value       = databricks_mws_workspaces.this.workspace_status
+}
+
+# =============================================================================
+# Network Outputs
+# =============================================================================
+
+output "vpc_id" {
+  description = "ID of the VPC used for the workspace"
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = module.vpc.private_subnets
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = module.vpc.public_subnets
+}
+
+output "nat_gateway_ids" {
+  description = "IDs of the NAT Gateways"
+  value       = module.vpc.natgw_ids
+}
+
+output "security_group_id" {
+  description = "ID of the security group used for the workspace"
+  value       = length(var.security_group_ids) > 0 ? var.security_group_ids[0] : module.vpc.default_security_group_id
+}
+
+# =============================================================================
+# IAM and Storage Outputs
+# =============================================================================
+
+output "cross_account_role_arn" {
+  description = "ARN of the cross-account IAM role"
+  value       = aws_iam_role.cross_account_role.arn
+}
+
+output "root_s3_bucket_name" {
+  description = "Name of the S3 bucket used for workspace root storage"
+  value       = aws_s3_bucket.root_storage_bucket.bucket
+}
+
+output "root_s3_bucket_arn" {
+  description = "ARN of the S3 bucket used for workspace root storage"
+  value       = aws_s3_bucket.root_storage_bucket.arn
+}
+
+# =============================================================================
+# Unity Catalog Outputs
+# =============================================================================
+
+output "metastore_id" {
+  description = "ID of the Unity Catalog metastore"
+  value       = var.metastore_id == "" ? databricks_metastore.metastore[0].id : var.metastore_id
+}
+
+output "metastore_name" {
+  description = "Name of the Unity Catalog metastore"
+  value       = var.metastore_id == "" ? databricks_metastore.metastore[0].name : var.metastore_name
+}
+
+output "catalog_name" {
+  description = "Name of the default Unity Catalog catalog"
+  value       = databricks_catalog.uc_quickstart.name
+}
+
+output "external_location_name" {
+  description = "Name of the Unity Catalog external location"
+  value       = databricks_external_location.uc_external_location.name
+}
+
+output "external_location_url" {
+  description = "URL of the Unity Catalog external location"
+  value       = databricks_external_location.uc_external_location.url
+}
+
+# =============================================================================
+# Databricks Account Objects Outputs
+# =============================================================================
+
+output "credentials_id" {
+  description = "ID of the Databricks credentials configuration"
+  value       = databricks_mws_credentials.this.credentials_id
+}
+
+output "storage_configuration_id" {
+  description = "ID of the Databricks storage configuration"
+  value       = databricks_mws_storage_configurations.this.storage_configuration_id
+}
+
+output "network_id" {
+  description = "ID of the Databricks network configuration"
+  value       = databricks_mws_networks.this.network_id
+}
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/providers.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/providers.tf
@@ -13,14 +13,17 @@ provider "aws" {
   }
 }
 
-# Authenticate using environment variables: https://registry.terraform.io/providers/databricks/databricks/latest/docs#argument-reference
-# export DATABRICKS_CLIENT_ID=CLIENT_ID
-# export DATABRICKS_CLIENT_SECRET=CLIENT_SECRET
+# OAuth M2M (service principal). For terraform plan/apply:
+#   export DATABRICKS_AUTH_TYPE=oauth-m2m
+#   export DATABRICKS_CLIENT_ID=...
+#   export DATABRICKS_CLIENT_SECRET=...   # SP OAuth secret, not a PAT
+#   unset DATABRICKS_HOST DATABRICKS_ACCOUNT_ID DATABRICKS_TOKEN
 
 provider "databricks" {
   alias      = "mws"
   host       = "https://accounts.cloud.databricks.com"
   account_id = var.databricks_account_id
+  auth_type  = "oauth-m2m"
 }
 
 provider "databricks" {

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/providers.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/providers.tf
@@ -1,0 +1,30 @@
+# Authenticate using environment variables: https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html
+# export AWS_ACCESS_KEY_ID=KEY_ID
+# export AWS_SECRET_ACCESS_KEY=SECRET_KEY
+# export AWS_SESSION_TOKEN=SESSION_TOKEN
+
+provider "aws" {
+  region = var.region
+  default_tags {
+    tags = {
+      Resource = var.resource_prefix
+      Project  = var.prefix
+    }
+  }
+}
+
+# Authenticate using environment variables: https://registry.terraform.io/providers/databricks/databricks/latest/docs#argument-reference
+# export DATABRICKS_CLIENT_ID=CLIENT_ID
+# export DATABRICKS_CLIENT_SECRET=CLIENT_SECRET
+
+provider "databricks" {
+  alias      = "mws"
+  host       = "https://accounts.cloud.databricks.com"
+  account_id = var.databricks_account_id
+}
+
+provider "databricks" {
+  alias = "workspace"
+  host  = databricks_mws_workspaces.this.workspace_url
+  workspace_id = databricks_mws_workspaces.this.workspace_id                                         
+}

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/providers.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/providers.tf
@@ -24,7 +24,7 @@ provider "databricks" {
 }
 
 provider "databricks" {
-  alias = "workspace"
-  host  = databricks_mws_workspaces.this.workspace_url
-  workspace_id = databricks_mws_workspaces.this.workspace_id                                         
+  alias        = "workspace"
+  host         = databricks_mws_workspaces.this.workspace_url
+  workspace_id = databricks_mws_workspaces.this.workspace_id
 }

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/root_s3_bucket.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/root_s3_bucket.tf
@@ -1,0 +1,32 @@
+resource "random_string" "bucket_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+resource "aws_s3_bucket" "root_storage_bucket" {
+  bucket        = "${var.resource_prefix}-workspace-root-storage-${random_string.bucket_suffix.result}"
+  force_destroy = true
+  tags = merge(
+    var.tags,
+    {
+      Name    = "${var.resource_prefix}-workspace-root-storage"
+      Project = var.resource_prefix
+    }
+  )
+}
+
+data "databricks_aws_bucket_policy" "this" {
+  databricks_e2_account_id = var.databricks_account_id
+  bucket                   = aws_s3_bucket.root_storage_bucket.bucket
+}
+
+resource "aws_s3_bucket_policy" "root_bucket_policy" {
+  bucket = aws_s3_bucket.root_storage_bucket.id
+  policy = data.databricks_aws_bucket_policy.this.json
+
+  lifecycle {
+    ignore_changes = [policy]
+  }
+}
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/security_group.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/security_group.tf
@@ -1,0 +1,38 @@
+resource "aws_vpc_security_group_egress_rule" "default_sg_egress_ports" {
+  for_each          = { for port in var.sg_egress_ports : tostring(port) => port }
+  security_group_id = module.vpc.default_security_group_id
+  from_port         = each.value
+  to_port           = each.value
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+  description       = "Allow outbound TCP traffic on port ${each.value}"
+  depends_on        = [module.vpc]
+}
+
+resource "aws_vpc_security_group_egress_rule" "default_sg_internal_tcp_egress" {
+  security_group_id            = module.vpc.default_security_group_id
+  referenced_security_group_id = module.vpc.default_security_group_id
+  ip_protocol                  = "tcp"
+  from_port                    = 0
+  to_port                      = 65535
+  description                  = "Allow all internal TCP egress traffic"
+  depends_on                   = [module.vpc]
+}
+
+resource "aws_vpc_security_group_egress_rule" "default_sg_internal_udp_egress" {
+  security_group_id            = module.vpc.default_security_group_id
+  referenced_security_group_id = module.vpc.default_security_group_id
+  ip_protocol                  = "udp"
+  from_port                    = 0
+  to_port                      = 65535
+  description                  = "Allow all internal UDP egress traffic"
+  depends_on                   = [module.vpc]
+}
+
+resource "aws_vpc_security_group_ingress_rule" "default_sg_self_ingress" {
+  security_group_id            = module.vpc.default_security_group_id
+  referenced_security_group_id = module.vpc.default_security_group_id
+  ip_protocol                  = "-1"
+  description                  = "Allow all traffic from self"
+  depends_on                   = [module.vpc]
+}

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/terraform.tfvars.example
@@ -46,7 +46,7 @@ intra_subnet_cidr    = ["10.0.201.0/24"]
 security_group_ids = []
 
 # Egress ports for Databricks connectivity
-sg_egress_ports = [443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
+sg_egress_ports = [443, 3306, 2443, 5432, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
 
 # =============================================================================
 # Unity Catalog Metastore Configuration

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/terraform.tfvars.example
@@ -1,0 +1,69 @@
+# =============================================================================
+# Databricks Configuration
+# =============================================================================
+
+# Your Databricks account ID (found in Databricks Account Console)
+databricks_account_id = "your-databricks-account-id"
+
+# Prefix for Databricks resources (workspace name, storage config, etc.)
+prefix = "my-databricks-workspace"
+
+# Prefix for AWS resources (VPC, S3, IAM, etc.)
+resource_prefix = "my-databricks-workspace"
+
+# Pricing tier of account (ENTERPRISE or PREMIUM)
+pricing_tier = "PREMIUM"
+
+# =============================================================================
+# AWS Configuration
+# =============================================================================
+
+# AWS region where resources will be deployed
+region = "us-west-2"
+
+# Optional: Additional tags for AWS resources
+# tags = {
+#   Environment = "production"
+#   Team        = "data-engineering"
+#   CostCenter  = "engineering"
+# }
+
+# =============================================================================
+# Network Configuration
+# =============================================================================
+
+vpc_cidr_range      = "10.0.0.0/16"
+availability_zones  = ["us-west-2a", "us-west-2b"]
+private_subnets_cidr = ["10.0.1.0/24", "10.0.2.0/24"]
+public_subnets_cidr  = ["10.0.101.0/24", "10.0.102.0/24"]
+intra_subnet_cidr    = ["10.0.201.0/24"]
+
+# =============================================================================
+# Security Group Configuration
+# =============================================================================
+
+# Optional: Use existing security groups (leave empty to use VPC default)
+security_group_ids = []
+
+# Egress ports for Databricks connectivity
+sg_egress_ports = [443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
+
+# =============================================================================
+# Unity Catalog Metastore Configuration
+# =============================================================================
+
+# Option 1: Create new metastore (leave metastore_id empty and specify name)
+metastore_id   = ""
+metastore_name = "my-unity-catalog-metastore"
+
+# Option 2: Use existing metastore (uncomment and specify ID)
+# metastore_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# =============================================================================
+# Unity Catalog Storage Configuration
+# =============================================================================
+
+# AWS account ID where Unity Catalog IAM role and S3 bucket will be created
+aws_account_id = "your-aws-account-id"
+
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/terraform.tfvars.example
@@ -66,4 +66,11 @@ metastore_name = "my-unity-catalog-metastore"
 # AWS account ID where Unity Catalog IAM role and S3 bucket will be created
 aws_account_id = "your-aws-account-id"
 
+# =============================================================================
+# User-defined Catalog in UC
+# =============================================================================
+# catalog_name              = "my_catalog"
+# external_location_name    = "my-external-location"
+# storage_credential_name   = "my-storage-credential"
+
 

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/unity_catalog.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/unity_catalog.tf
@@ -1,6 +1,7 @@
-# Wait to prevent race condition between IAM role and external location validation
+# Delay after IAM policy is attached so AWS / UC propagation can settle before
+# Databricks validates S3 read on external location creation.
 resource "time_sleep" "wait_60_seconds" {
-  depends_on      = [null_resource.previous]
+  depends_on      = [aws_iam_policy_attachment.unity_catalog_attach]
   create_duration = "60s"
 }
 
@@ -8,6 +9,11 @@ locals {
   uc_iam_role         = "${var.resource_prefix}-catalog"
   uc_catalog_name_us  = replace(var.prefix, "-", "_")
   catalog_bucket_name = "${var.resource_prefix}-catalog-storage-${random_string.catalog_bucket_suffix.result}"
+
+  # Resolved UC object names (optional vars default to "" in variables.tf; prefix-based defaults cannot live in variable defaults)
+  uc_catalog_name            = var.catalog_name != "" ? var.catalog_name : "${var.prefix}-catalog"
+  uc_external_location_name  = var.external_location_name != "" ? var.external_location_name : "${var.resource_prefix}-external-location"
+  uc_storage_credential_name = var.storage_credential_name != "" ? var.storage_credential_name : "${var.resource_prefix}-storage-credential"
 }
 
 resource "random_string" "catalog_bucket_suffix" {
@@ -19,7 +25,7 @@ resource "random_string" "catalog_bucket_suffix" {
 # Storage Credential (created before role): https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/unity-catalog#configure-external-locations-and-credentials
 resource "databricks_storage_credential" "uc_storage_cred" {
   provider = databricks.workspace
-  name     = "${var.resource_prefix}-storage-credential"
+  name     = local.uc_storage_credential_name
   aws_iam_role {
     role_arn = "arn:aws:iam::${var.aws_account_id}:role/${local.uc_iam_role}"
   }
@@ -89,17 +95,17 @@ resource "aws_s3_bucket_public_access_block" "unity_catalog" {
 # External Location
 resource "databricks_external_location" "uc_external_location" {
   provider        = databricks.workspace
-  name            = "${var.resource_prefix}-external-location"
+  name            = local.uc_external_location_name
   url             = "s3://${aws_s3_bucket.unity_catalog_bucket.id}"
   credential_name = databricks_storage_credential.uc_storage_cred.id
   force_destroy   = true
-  depends_on      = [aws_iam_policy_attachment.unity_catalog_attach, time_sleep.wait_60_seconds]
+  depends_on      = [time_sleep.wait_60_seconds]
 }
 resource "databricks_catalog" "uc_quickstart" {
-  provider     = databricks.workspace
-  name         = var.prefix
+  provider = databricks.workspace
+  name     = local.uc_catalog_name
   # storage_root = "${var.storage_root}"
-  storage_root = databricks_external_location.uc_external_location.url
+  storage_root  = databricks_external_location.uc_external_location.url
   comment       = "this catalog is managed by terraform"
   force_destroy = true
   # enable_predictive_optimization = "ENABLE"

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/unity_catalog.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/unity_catalog.tf
@@ -102,9 +102,8 @@ resource "databricks_external_location" "uc_external_location" {
   depends_on      = [time_sleep.wait_60_seconds]
 }
 resource "databricks_catalog" "uc_quickstart" {
-  provider = databricks.workspace
-  name     = local.uc_catalog_name
-  # storage_root = "${var.storage_root}"
+  provider      = databricks.workspace
+  name          = local.uc_catalog_name
   storage_root  = databricks_external_location.uc_external_location.url
   comment       = "this catalog is managed by terraform"
   force_destroy = true

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/unity_catalog.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/unity_catalog.tf
@@ -1,0 +1,110 @@
+# Wait to prevent race condition between IAM role and external location validation
+resource "time_sleep" "wait_60_seconds" {
+  depends_on      = [null_resource.previous]
+  create_duration = "60s"
+}
+
+locals {
+  uc_iam_role         = "${var.resource_prefix}-catalog"
+  uc_catalog_name_us  = replace(var.prefix, "-", "_")
+  catalog_bucket_name = "${var.resource_prefix}-catalog-storage-${random_string.catalog_bucket_suffix.result}"
+}
+
+resource "random_string" "catalog_bucket_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+# Storage Credential (created before role): https://registry.terraform.io/providers/databricks/databricks/latest/docs/guides/unity-catalog#configure-external-locations-and-credentials
+resource "databricks_storage_credential" "uc_storage_cred" {
+  provider = databricks.workspace
+  name     = "${var.resource_prefix}-storage-credential"
+  aws_iam_role {
+    role_arn = "arn:aws:iam::${var.aws_account_id}:role/${local.uc_iam_role}"
+  }
+  depends_on = [databricks_metastore_assignment.this]
+}
+
+# Unity Catalog Trust Policy - Data Source
+data "databricks_aws_unity_catalog_assume_role_policy" "unity_catalog" {
+  provider              = databricks.workspace
+  aws_account_id        = var.aws_account_id
+  aws_partition         = "aws"
+  role_name             = local.uc_iam_role
+  unity_catalog_iam_arn = "arn:aws:iam::414351767826:role/unity-catalog-prod-UCMasterRole-14S5ZJVKOTYTL"
+  external_id           = databricks_storage_credential.uc_storage_cred.aws_iam_role[0].external_id
+}
+
+# Unity Catalog Policy - Data Source
+data "databricks_aws_unity_catalog_policy" "unity_catalog" {
+  provider       = databricks.workspace
+  aws_account_id = var.aws_account_id
+  aws_partition  = "aws"
+  bucket_name    = local.catalog_bucket_name
+  role_name      = local.uc_iam_role
+}
+
+# Unity Catalog Policy
+resource "aws_iam_policy" "unity_catalog" {
+  name   = "${var.prefix}-catalog-policy"
+  policy = data.databricks_aws_unity_catalog_policy.unity_catalog.json
+}
+
+# Unity Catalog Role
+resource "aws_iam_role" "unity_catalog" {
+  name               = local.uc_iam_role
+  assume_role_policy = data.databricks_aws_unity_catalog_assume_role_policy.unity_catalog.json
+}
+
+# Unity Catalog Policy Attachment
+resource "aws_iam_policy_attachment" "unity_catalog_attach" {
+  name       = "${var.prefix}-unity_catalog_policy_attach"
+  roles      = [aws_iam_role.unity_catalog.name]
+  policy_arn = aws_iam_policy.unity_catalog.arn
+}
+
+# Unity Catalog S3
+resource "aws_s3_bucket" "unity_catalog_bucket" {
+  bucket        = local.catalog_bucket_name
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_versioning" "unity_catalog_versioning" {
+  bucket = aws_s3_bucket.unity_catalog_bucket.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "unity_catalog" {
+  bucket                  = aws_s3_bucket.unity_catalog_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+  depends_on              = [aws_s3_bucket.unity_catalog_bucket]
+}
+
+# External Location
+resource "databricks_external_location" "uc_external_location" {
+  provider        = databricks.workspace
+  name            = "${var.resource_prefix}-external-location"
+  url             = "s3://${aws_s3_bucket.unity_catalog_bucket.id}"
+  credential_name = databricks_storage_credential.uc_storage_cred.id
+  force_destroy   = true
+  depends_on      = [aws_iam_policy_attachment.unity_catalog_attach, time_sleep.wait_60_seconds]
+}
+resource "databricks_catalog" "uc_quickstart" {
+  provider     = databricks.workspace
+  name         = var.prefix
+  # storage_root = "${var.storage_root}"
+  storage_root = databricks_external_location.uc_external_location.url
+  comment       = "this catalog is managed by terraform"
+  force_destroy = true
+  # enable_predictive_optimization = "ENABLE"
+  # isolation_mode = "OPEN"
+  # properties = {
+  #   purpose = "development"
+  # }
+}

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/variables.tf
@@ -1,0 +1,131 @@
+# =============================================================================
+# Databricks Configuration
+# =============================================================================
+
+variable "databricks_account_id" {
+  description = "ID of the Databricks account"
+  type        = string
+  sensitive   = true
+}
+
+variable "prefix" {
+  description = "Prefix for Databricks resource names (workspace name, storage config, etc.)"
+  type        = string
+  default     = "databricks-workspace"
+}
+
+variable "resource_prefix" {
+  description = "Prefix for naming AWS resources (VPC, S3, IAM, etc.)"
+  type        = string
+  default     = "databricks-workspace"
+  validation {
+    condition     = can(regex("^[a-z0-9-.]{1,40}$", var.resource_prefix))
+    error_message = "Invalid resource prefix. Allowed 40 characters containing only a-z, 0-9, -, ."
+  }
+}
+
+variable "pricing_tier" {
+  description = "Pricing tier for Databricks workspace"
+  type        = string
+  default     = "PREMIUM"
+  validation {
+    condition     = contains(["ENTERPRISE", "PREMIUM"], var.pricing_tier)
+    error_message = "resource_prefix must be either 'ENTERPRISE' or 'PREMIUM'."
+  }
+}
+
+# =============================================================================
+# AWS Configuration
+# =============================================================================
+
+variable "region" {
+  description = "AWS region code where resources will be deployed"
+  type        = string
+  validation {
+    condition = contains([
+      "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1",
+      "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-west-1",
+      "eu-west-2", "eu-west-3", "sa-east-1", "us-east-1", "us-east-2", "us-west-2"
+    ], var.region)
+    error_message = "Valid values for var.region are standard AWS regions supported by Databricks."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all AWS resources"
+  type        = map(string)
+  default     = {}
+}
+
+# =============================================================================
+# Network Configuration
+# =============================================================================
+
+variable "vpc_cidr_range" {
+  description = "CIDR range for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of AWS availability zones for subnet distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnets_cidr" {
+  description = "List of private subnet CIDR blocks"
+  type        = list(string)
+  default     = []
+}
+
+variable "public_subnets_cidr" {
+  description = "List of public subnet CIDR blocks"
+  type        = list(string)
+  default     = []
+}
+
+variable "intra_subnet_cidr" {
+  description = "List of intra subnet CIDR blocks that contain the VPC endpoints"
+  type        = list(string)
+  default     = []
+}
+
+# =============================================================================
+# Security Group Configuration
+# =============================================================================
+
+variable "security_group_ids" {
+  description = "Existing security group IDs to use. If empty, default VPC security group will be used"
+  type        = list(string)
+  default     = []
+}
+
+variable "sg_egress_ports" {
+  description = "List of egress ports to allow in security group rules"
+  type        = list(number)
+  default     = [443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
+}
+
+# =============================================================================
+# Unity Catalog Metastore Configuration
+# =============================================================================
+
+variable "aws_account_id" {
+  description = "AWS account ID where resources are deployed (used to construct IAM role ARNs for Unity Catalog)"
+  type        = string
+}
+
+variable "metastore_id" {
+  description = "Existing Unity Catalog metastore ID. If empty, a new metastore will be created"
+  type        = string
+  default     = ""
+}
+
+variable "metastore_name" {
+  description = "Name for the Unity Catalog metastore (only used if creating new metastore)"
+  type        = string
+  default     = ""
+}
+
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/variables.tf
@@ -104,7 +104,7 @@ variable "security_group_ids" {
 variable "sg_egress_ports" {
   description = "List of egress ports to allow in security group rules"
   type        = list(number)
-  default     = [443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
+  default     = [443, 3306, 2443, 5432, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
 }
 
 # =============================================================================

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/variables.tf
@@ -127,5 +127,23 @@ variable "metastore_name" {
   type        = string
   default     = ""
 }
+# =============================================================================
+# User Defined Catalog
+# =============================================================================
+variable "catalog_name" {
+  description = "Name for the user defined catalog"
+  type        = string
+  default     = ""
+}
 
+variable "external_location_name" {
+  description = "Name for the user defined external location"
+  type        = string
+  default     = ""
+}
 
+variable "storage_credential_name" {
+  description = "Name for the user defined storage credential (Unity Catalog). If empty, defaults to \"{resource_prefix}-storage-credential\""
+  type        = string
+  default     = ""
+}

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/variables.tf
@@ -30,7 +30,7 @@ variable "pricing_tier" {
   default     = "PREMIUM"
   validation {
     condition     = contains(["ENTERPRISE", "PREMIUM"], var.pricing_tier)
-    error_message = "resource_prefix must be either 'ENTERPRISE' or 'PREMIUM'."
+    error_message = "pricing_tier must be either 'ENTERPRISE' or 'PREMIUM'."
   }
 }
 
@@ -123,9 +123,13 @@ variable "metastore_id" {
 }
 
 variable "metastore_name" {
-  description = "Name for the Unity Catalog metastore (only used if creating new metastore)"
+  description = "Name for the Unity Catalog metastore. Required only when metastore_id is empty (new metastore)."
   type        = string
   default     = ""
+  validation {
+    condition     = var.metastore_id != "" || var.metastore_name != ""
+    error_message = "metastore_name is required when creating a new metastore (metastore_id is empty)."
+  }
 }
 # =============================================================================
 # User Defined Catalog

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/versions.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/versions.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    databricks = {
+      source  = "databricks/databricks"
+      version = "~> 1.84"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.76, < 7.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/versions.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/versions.tf
@@ -18,10 +18,6 @@ terraform {
       source  = "hashicorp/time"
       version = "~> 0.9"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.0"
-    }
   }
 }
 

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/workspace.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/workspace.tf
@@ -1,0 +1,47 @@
+resource "null_resource" "previous" {}
+
+resource "time_sleep" "wait_30_seconds" {
+  depends_on      = [null_resource.previous]
+  create_duration = "30s"
+}
+
+resource "databricks_mws_storage_configurations" "this" {
+  provider                   = databricks.mws
+  account_id                 = var.databricks_account_id
+  storage_configuration_name = "${var.prefix}-storage"
+  bucket_name                = aws_s3_bucket.root_storage_bucket.bucket
+}
+
+resource "databricks_mws_credentials" "this" {
+  provider         = databricks.mws
+  role_arn         = aws_iam_role.cross_account_role.arn
+  credentials_name = "${var.prefix}-creds"
+  depends_on       = [time_sleep.wait_30_seconds]
+}
+
+resource "databricks_mws_workspaces" "this" {
+  provider                 = databricks.mws
+  account_id               = var.databricks_account_id
+  aws_region               = var.region
+  workspace_name           = var.prefix
+  credentials_id           = databricks_mws_credentials.this.credentials_id
+  storage_configuration_id = databricks_mws_storage_configurations.this.storage_configuration_id
+  network_id               = databricks_mws_networks.this.network_id
+  pricing_tier             = var.pricing_tier
+  depends_on               = [databricks_mws_networks.this]
+}
+
+resource "databricks_mws_networks" "this" {
+  provider           = databricks.mws
+  account_id         = var.databricks_account_id
+  network_name       = "${var.prefix}-network"
+  security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : [module.vpc.default_security_group_id]
+  subnet_ids         = module.vpc.private_subnets
+  vpc_id             = module.vpc.vpc_id
+}
+
+resource "time_sleep" "wait_2_minutes" {
+  depends_on      = [databricks_mws_workspaces.this]
+  create_duration = "120s"
+}
+

--- a/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/workspace.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc-uc/tf/workspace.tf
@@ -1,7 +1,4 @@
-resource "null_resource" "previous" {}
-
 resource "time_sleep" "wait_30_seconds" {
-  depends_on      = [null_resource.previous]
   create_duration = "30s"
 }
 

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/terraform.tfvars.example
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/terraform.tfvars.example
@@ -55,7 +55,7 @@ security_group_ids = []
 # new_security_group_name = "my-databricks-sg"
 
 # Egress ports for Databricks connectivity
-sg_egress_ports = [443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
+sg_egress_ports = [443, 3306, 2443, 5432, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
 
 # =============================================================================
 # Unity Catalog Metastore Configuration

--- a/workspace-setup/terraform-examples/aws/aws-byovpc/tf/variables.tf
+++ b/workspace-setup/terraform-examples/aws/aws-byovpc/tf/variables.tf
@@ -116,7 +116,7 @@ variable "security_group_ids" {
 variable "sg_egress_ports" {
   description = "List of egress ports to allow in security group rules"
   type        = list(number)
-  default     = [443, 3306, 2443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
+  default     = [443, 3306, 2443, 5432, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
 }
 
 variable "new_security_group_name" {

--- a/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/outputs.tf
+++ b/workspace-setup/terraform-examples/azure/azure-vnet-injection-uc/tf/outputs.tf
@@ -71,7 +71,7 @@ output "external_location_name" {
 }
 
 output "catalog_name" {
-  description = "Name of the default Unity Catalog catalog"
+  description = "Name of the user-defined Unity Catalog catalog"
   value       = databricks_catalog.uc_quickstart_sandbox.name
 }
 


### PR DESCRIPTION
# Pull Request

## Description
Introduces a new Terraform solution which deploys an AWS classic workspace and additionally adds a user-defined catalog , so that the customer can start using Unity Catalog from the start.

## Category
- [ ] core-platform
- [ ] data-engineering
- [ ] data-governance
- [ ] data-warehousing  
- [ ] genai-ml
- [ ] launch-accelerator
- [X] workspace-setup

## Type of Change
- [X] New project
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Project Details
**Project Name:** AWS workspace setup with VPC-injection and a user-defined catalog in UC
**Purpose:** Builds on top of the aws-byovpc solution and additionally adds a user-defined catalog , so that the customer can start using Unity Catalog from the start.
**Technologies Used:** Terraform

## Testing
- [X] Code runs without errors
- [X] Documentation is complete
- [X] Used only synthetic data

## Security Compliance ✅
- [X] No customer data, PII, or proprietary information
- [X] No credentials or access tokens
- [X] Only synthetic data used
- [X] Third-party licenses acknowledged

---

**By submitting this PR, I confirm I have followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and security requirements.**