### PR TITLE
Add managed-vnet-to-vnet-injection PowerShell scripts

### DIFF
--- a/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/README.md
+++ b/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/README.md
@@ -1,0 +1,99 @@
+# Azure Databricks VNet Injection Updater
+
+This project provides PowerShell scripts to automate the process of updating an Azure Databricks workspace to use VNet Injection (or updating its VNet configuration), as described in the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/update-workspaces).
+
+## Prerequisites
+
+- **Azure CLI (`az`)**: Installed and logged in.
+- **PowerShell**: Required to run the script (available in Azure Cloud Shell).
+- **Before you begin** (per [Microsoft Learn](https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/update-workspaces)): confirm the workspace is **not** configured with Azure Load Balancer (otherwise contact your account team); **terminate all running clusters and jobs** to avoid disruption during the update.
+- **Virtual Network (VNet) Configuration**:
+  - Must be in the **same region** as the Databricks Workspace.
+  - **Subnets**: Requires two subnets (public and private).
+  - **Delegation**: Each subnet must be delegated to `Microsoft.Databricks/workspaces`.
+  - **Network Security Group (NSG)**: Each subnet must have an NSG associated (typically an empty one).
+  - **Outbound Connectivity**: If using No Public IP (NPIP) / Secure Cluster Connectivity, an explicit outbound method (NAT Gateway, Firewall, or Load Balancer) must be configured on the subnets.
+
+## Important Considerations
+
+- **Permissions**: The user or service principal running the script must possess sufficient privileges to deploy and modify the required Azure resources on both the existing Databricks workspace and the new VNet. Example Azure RBAC roles that grant the needed access:
+  - **Owner** on the workspace resource group and the VNet resource group (broadest, simplest option).
+  - **Contributor** on both resource groups, combined with **User Access Administrator** if role assignments need to be created.
+  - Scoped alternative: **Contributor** on the Databricks workspace + **Network Contributor** on the VNet (and **User Access Administrator** if role assignments are required).
+- **Downtime**: This conversion requires planned downtime. Due to the complexity of a potential rollback, allocate ample time for the activity.
+- **Private Link (PL) Endpoints**: Private Link endpoints cannot be hosted on the subnets delegated to the Databricks workspace. A separate subnet must be used for hosting PL endpoints.
+- **Subnet Usage**: Use subnets that are not currently in use by other Databricks workspaces to avoid potential deployment errors.
+
+## Usage
+
+These scripts are ideal for running in the **Azure Cloud Shell** (PowerShell mode).
+
+### Optional: Create a Databricks-ready VNet
+
+`create_databricks_vnet.ps1` is optional. Use it when you do not already have a target VNet prepared for Databricks VNet injection.
+
+The script creates everything needed for the workspace upgrade to complete without the common VNet validation failures:
+
+- A resource group if it does not already exist.
+- A VNet in the requested region.
+- Public and private subnets.
+- NSGs associated to both subnets.
+- `Microsoft.Databricks/workspaces` delegation on both subnets.
+- An `owner` tag using the Azure CLI user running the script.
+
+If CIDR ranges are not provided, it uses:
+
+- VNet: `10.0.0.0/16`
+- Public subnet: `10.0.1.0/24`
+- Private subnet: `10.0.2.0/24`
+
+```powershell
+./create_databricks_vnet.ps1 `
+  -ResourceGroupName "<network-rg-name>" `
+  -Location "<azure-region>"
+```
+
+After it finishes, the script prints the `VNetId`, public subnet name, and private subnet name to use with the workspace update script.
+
+### Update the Databricks workspace
+
+```powershell
+./update_databricks_vnet.ps1 `
+  -WorkspaceId "/subscriptions/<sub-id>/resourceGroups/<rg-name>/providers/Microsoft.Databricks/workspaces/<workspace-name>" `
+  -VNetId "/subscriptions/<sub-id>/resourceGroups/<rg-name>/providers/Microsoft.Network/virtualNetworks/<vnet-name>" `
+  -PublicSubnetName "my-public-subnet" `
+  -PrivateSubnetName "my-private-subnet"
+```
+
+### Script Features
+
+1. **Validation**: Checks if the provided VNet and Subnets exist.
+   - **Subscription Check**: Ensures the VNet is in the same subscription as the Workspace.
+   - **Region Check**: Ensures the VNet is in the same region as the Workspace.
+   - **Delegation Check**: Ensures subnets are delegated to `Microsoft.Databricks/workspaces`.
+   - **NSG Check**: Ensures subnets have a Network Security Group associated (consistent with the NSG + quickstart VNet steps in the documentation).
+2. **Subnet selection**: If public or private subnet names are omitted, the script lists the target VNet subnets and prompts you to choose them.
+3. **Managed VNet peerings**: If the workspace uses a **managed** VNet (`customVirtualNetworkId` not set on the workspace resource), the script checks VNet peerings on any virtual network in the workspace **managed resource group**. Existing managed VNet peerings must be removed before the migration continues.
+4. **Export**: Exports the current ARM template of the specified Databricks Workspace and ignores the known `Microsoft.Databricks/workspaces/privateEndpointConnections` export limitation for managed VNet workspaces.
+5. **Modification** (aligned with [Step 3 in Microsoft Learn](https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/update-workspaces)):
+   - Sets the workspace resource `apiVersion` to **`2026-01-01`**.
+   - Removes legacy parameters from `properties.parameters` when present: `vnetAddressPrefix`, `natGatewayName`, `publicIpName`.
+   - Sets VNet injection parameters: `customVirtualNetworkId`, `customPublicSubnetName`, `customPrivateSubnetName`.
+   - Strips read-only `provisioningState` from the exported resource when present.
+   - Fills missing template parameter defaults for workspace name–like parameters when possible.
+6. **Deployment**: Redeploys the updated template with incremental mode.
+
+## Post-Deployment Testing
+
+After the script finishes, validate the workspace is correctly using the injected VNet:
+
+1. Confirm that the **Networking settings** in your workspace are no longer grayed out.
+2. Spin up a compute resource (cluster).
+3. Locate the corresponding Virtual Machine (VM) in Azure using the cluster name in its tags.
+4. Confirm that the VM is running within the VNet and subnets specified during the VNet injection process.
+
+## Notes
+
+- Ensure the new VNet and subnets have the correct delegations (`Microsoft.Databricks/workspaces`) before running `update_databricks_vnet.ps1`, or use the optional VNet creation script to create a compliant network first.
+- The script uses the current Azure CLI session. Run `az login` first if running locally.
+- Microsoft documents that **Terraform is not supported** for this workspace network update path; this script uses ARM export and `az deployment group create` instead.

--- a/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/README.md
+++ b/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/README.md
@@ -97,3 +97,19 @@ After the script finishes, validate the workspace is correctly using the injecte
 - Ensure the new VNet and subnets have the correct delegations (`Microsoft.Databricks/workspaces`) before running `update_databricks_vnet.ps1`, or use the optional VNet creation script to create a compliant network first.
 - The script uses the current Azure CLI session. Run `az login` first if running locally.
 - Microsoft documents that **Terraform is not supported** for this workspace network update path; this script uses ARM export and `az deployment group create` instead.
+
+## Related Content
+
+- [Update workspace network configuration (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/update-workspaces) — the official documentation this project automates, including the managed-VNet-to-VNet-injection steps and the supported `apiVersion`.
+- [Video walkthrough: Update your workspace network configuration to use VNet injection](https://www.youtube.com/watch?v=q_JYv7j2FRs) — a step-by-step demonstration of the workspace network update process.
+- [Configure a workspace with VNet injection (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/vnet-inject) — background on VNet injection requirements (subnets, delegation, NSGs).
+- [Azure Databricks: Upgrade Managed Workspace to VNet Injected Workspace (Community)](https://community.databricks.com/t5/product-platform-updates/azure-databricks-upgrade-managed-workspace-to-vnet-injected/ba-p/130655) — Azure Portal UI alternative to the ARM-template approach.
+
+## Disclaimer
+
+⚠️ **Please Note**:
+- These scripts are provided **as-is** for guidance and educational purposes.
+- They are **not official Databricks tools** or supported products.
+- This project **does not have official Databricks support** — Databricks support channels do not cover these community-contributed examples.
+- Content represents implementation examples and best-practice guidance; always refer to the [official Microsoft documentation](https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/update-workspaces) as the source of truth.
+- Users should thoroughly test and validate all code in their specific environments before running against production workspaces.

--- a/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/create_databricks_vnet.ps1
+++ b/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/create_databricks_vnet.ps1
@@ -1,0 +1,245 @@
+<#
+.SYNOPSIS
+    Creates an Azure VNet prepared for Azure Databricks VNet injection.
+
+.DESCRIPTION
+    This script creates a resource group if needed, then creates a VNet with public and private subnets.
+    Both subnets are associated with Network Security Groups and delegated to Microsoft.Databricks/workspaces.
+    Created resources are tagged with owner=<current Azure CLI user>.
+
+    If CIDR values are not supplied, these defaults are used:
+      VNet:           10.0.0.0/16
+      Public subnet:  10.0.1.0/24
+      Private subnet: 10.0.2.0/24
+
+.EXAMPLE
+    ./create_databricks_vnet.ps1 -ResourceGroupName "rg-databricks-network" -Location "eastus"
+
+.EXAMPLE
+    ./create_databricks_vnet.ps1 -ResourceGroupName "rg-databricks-network" -Location "eastus" -VNetName "adb-vnet" -VNetCidr "10.20.0.0/16" -PublicSubnetCidr "10.20.1.0/24" -PrivateSubnetCidr "10.20.2.0/24"
+#>
+
+param(
+    [Parameter(Mandatory = $false, HelpMessage = "Resource group where the VNet will be created")]
+    [string]$ResourceGroupName,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Azure region for the resource group and VNet")]
+    [Alias("Region")]
+    [string]$Location,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Name of the VNet to create")]
+    [string]$VNetName,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Address space for the VNet")]
+    [string]$VNetCidr,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Name of the public subnet")]
+    [string]$PublicSubnetName,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Address range for the public subnet")]
+    [string]$PublicSubnetCidr,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Name of the private subnet")]
+    [string]$PrivateSubnetName,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Address range for the private subnet")]
+    [string]$PrivateSubnetCidr
+)
+
+$ErrorActionPreference = "Stop"
+
+$DefaultVNetName = "databricks-vnet"
+$DefaultPublicSubnetName = "public-subnet"
+$DefaultPrivateSubnetName = "private-subnet"
+$DefaultVNetCidr = "10.0.0.0/16"
+$DefaultPublicSubnetCidr = "10.0.1.0/24"
+$DefaultPrivateSubnetCidr = "10.0.2.0/24"
+
+function Read-RequiredValue {
+    param(
+        [string]$Prompt,
+        [string]$CurrentValue
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($CurrentValue)) {
+        return $CurrentValue
+    }
+
+    do {
+        $value = Read-Host $Prompt
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            Write-Warning "A value is required."
+        }
+    } while ([string]::IsNullOrWhiteSpace($value))
+
+    return $value
+}
+
+function Read-ValueWithDefault {
+    param(
+        [string]$Prompt,
+        [string]$CurrentValue,
+        [string]$DefaultValue
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($CurrentValue)) {
+        return $CurrentValue
+    }
+
+    $value = Read-Host "$Prompt [$DefaultValue]"
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $DefaultValue
+    }
+
+    return $value
+}
+
+function Assert-LastCommandSucceeded {
+    param([string]$Message)
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error $Message
+        exit 1
+    }
+}
+
+function Test-AzCliResourceExists {
+    param([scriptblock]$Command)
+
+    & $Command *> $null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Set-OwnerTag {
+    param(
+        [string]$ResourceId,
+        [string]$Owner
+    )
+
+    az tag update --resource-id $ResourceId --operation Merge --tags owner=$Owner --output none
+    Assert-LastCommandSucceeded "Failed to set owner tag on '$ResourceId'."
+}
+
+if (-not (Get-Command "az" -ErrorAction SilentlyContinue)) {
+    Write-Error "Azure CLI ('az') is not installed or not in the path."
+    exit 1
+}
+
+$account = az account show --output json | ConvertFrom-Json
+Assert-LastCommandSucceeded "Azure CLI is not logged in. Run 'az login' before using this script."
+
+$OwnerTagValue = $account.user.name
+if ([string]::IsNullOrWhiteSpace($OwnerTagValue)) {
+    $OwnerTagValue = $account.name
+}
+
+if ([string]::IsNullOrWhiteSpace($OwnerTagValue)) {
+    Write-Error "Unable to determine the current Azure CLI user for the owner tag."
+    exit 1
+}
+
+$ResourceGroupName = Read-RequiredValue -Prompt "Resource group name" -CurrentValue $ResourceGroupName
+$Location = Read-RequiredValue -Prompt "Azure region, for example eastus" -CurrentValue $Location
+$VNetName = Read-ValueWithDefault -Prompt "VNet name" -CurrentValue $VNetName -DefaultValue $DefaultVNetName
+$VNetCidr = Read-ValueWithDefault -Prompt "VNet CIDR" -CurrentValue $VNetCidr -DefaultValue $DefaultVNetCidr
+$PublicSubnetName = Read-ValueWithDefault -Prompt "Public subnet name" -CurrentValue $PublicSubnetName -DefaultValue $DefaultPublicSubnetName
+$PublicSubnetCidr = Read-ValueWithDefault -Prompt "Public subnet CIDR" -CurrentValue $PublicSubnetCidr -DefaultValue $DefaultPublicSubnetCidr
+$PrivateSubnetName = Read-ValueWithDefault -Prompt "Private subnet name" -CurrentValue $PrivateSubnetName -DefaultValue $DefaultPrivateSubnetName
+$PrivateSubnetCidr = Read-ValueWithDefault -Prompt "Private subnet CIDR" -CurrentValue $PrivateSubnetCidr -DefaultValue $DefaultPrivateSubnetCidr
+
+if ($PublicSubnetName -eq $PrivateSubnetName) {
+    Write-Error "PublicSubnetName and PrivateSubnetName must be different."
+    exit 1
+}
+
+if ($PublicSubnetCidr -eq $PrivateSubnetCidr) {
+    Write-Error "PublicSubnetCidr and PrivateSubnetCidr must be different."
+    exit 1
+}
+
+$PublicNsgName = "$VNetName-public-nsg"
+$PrivateNsgName = "$VNetName-private-nsg"
+
+Write-Host "Checking resource group..." -ForegroundColor Cyan
+$rgExists = az group exists --name $ResourceGroupName --output tsv
+Assert-LastCommandSucceeded "Failed to check whether resource group '$ResourceGroupName' exists."
+
+if ($rgExists -ne "true") {
+    Write-Host "Creating resource group '$ResourceGroupName' in '$Location'..." -ForegroundColor Cyan
+    az group create --name $ResourceGroupName --location $Location --tags owner=$OwnerTagValue --output none
+    Assert-LastCommandSucceeded "Failed to create resource group '$ResourceGroupName'."
+} else {
+    Write-Host "Resource group '$ResourceGroupName' already exists." -ForegroundColor DarkGray
+    $resourceGroup = az group show --name $ResourceGroupName --output json | ConvertFrom-Json
+    Assert-LastCommandSucceeded "Failed to read resource group '$ResourceGroupName'."
+    Set-OwnerTag -ResourceId $resourceGroup.id -Owner $OwnerTagValue
+}
+
+if (Test-AzCliResourceExists { az network vnet show --resource-group $ResourceGroupName --name $VNetName --output none }) {
+    Write-Error "VNet '$VNetName' already exists in resource group '$ResourceGroupName'. Choose a different VNetName or delete the existing VNet."
+    exit 1
+}
+
+Write-Host "Creating NSGs..." -ForegroundColor Cyan
+if (-not (Test-AzCliResourceExists { az network nsg show --resource-group $ResourceGroupName --name $PublicNsgName --output none })) {
+    az network nsg create --resource-group $ResourceGroupName --name $PublicNsgName --location $Location --tags owner=$OwnerTagValue --output none
+    Assert-LastCommandSucceeded "Failed to create NSG '$PublicNsgName'."
+} else {
+    $publicNsg = az network nsg show --resource-group $ResourceGroupName --name $PublicNsgName --output json | ConvertFrom-Json
+    Assert-LastCommandSucceeded "Failed to read NSG '$PublicNsgName'."
+    Set-OwnerTag -ResourceId $publicNsg.id -Owner $OwnerTagValue
+}
+
+if (-not (Test-AzCliResourceExists { az network nsg show --resource-group $ResourceGroupName --name $PrivateNsgName --output none })) {
+    az network nsg create --resource-group $ResourceGroupName --name $PrivateNsgName --location $Location --tags owner=$OwnerTagValue --output none
+    Assert-LastCommandSucceeded "Failed to create NSG '$PrivateNsgName'."
+} else {
+    $privateNsg = az network nsg show --resource-group $ResourceGroupName --name $PrivateNsgName --output json | ConvertFrom-Json
+    Assert-LastCommandSucceeded "Failed to read NSG '$PrivateNsgName'."
+    Set-OwnerTag -ResourceId $privateNsg.id -Owner $OwnerTagValue
+}
+
+Write-Host "Creating VNet '$VNetName' with public subnet '$PublicSubnetName'..." -ForegroundColor Cyan
+az network vnet create `
+    --resource-group $ResourceGroupName `
+    --name $VNetName `
+    --location $Location `
+    --address-prefixes $VNetCidr `
+    --subnet-name $PublicSubnetName `
+    --subnet-prefixes $PublicSubnetCidr `
+    --network-security-group $PublicNsgName `
+    --tags owner=$OwnerTagValue `
+    --output none
+Assert-LastCommandSucceeded "Failed to create VNet '$VNetName'."
+
+Write-Host "Delegating public subnet to Microsoft.Databricks/workspaces..." -ForegroundColor Cyan
+az network vnet subnet update `
+    --resource-group $ResourceGroupName `
+    --vnet-name $VNetName `
+    --name $PublicSubnetName `
+    --delegations Microsoft.Databricks/workspaces `
+    --output none
+Assert-LastCommandSucceeded "Failed to delegate public subnet '$PublicSubnetName'."
+
+Write-Host "Creating private subnet '$PrivateSubnetName'..." -ForegroundColor Cyan
+az network vnet subnet create `
+    --resource-group $ResourceGroupName `
+    --vnet-name $VNetName `
+    --name $PrivateSubnetName `
+    --address-prefixes $PrivateSubnetCidr `
+    --network-security-group $PrivateNsgName `
+    --delegations Microsoft.Databricks/workspaces `
+    --output none
+Assert-LastCommandSucceeded "Failed to create private subnet '$PrivateSubnetName'."
+
+$vnet = az network vnet show --resource-group $ResourceGroupName --name $VNetName --output json | ConvertFrom-Json
+Assert-LastCommandSucceeded "Failed to read VNet '$VNetName' after creation."
+
+Write-Host ""
+Write-Host "Databricks-ready VNet created successfully." -ForegroundColor Green
+Write-Host "VNet ID: $($vnet.id)"
+Write-Host "Public subnet: $PublicSubnetName ($PublicSubnetCidr)"
+Write-Host "Private subnet: $PrivateSubnetName ($PrivateSubnetCidr)"
+Write-Host ""
+Write-Host "Use this with update_databricks_vnet.ps1:" -ForegroundColor Cyan
+Write-Host "./update_databricks_vnet.ps1 -WorkspaceId `"<workspace-resource-id>`" -VNetId `"$($vnet.id)`" -PublicSubnetName `"$PublicSubnetName`" -PrivateSubnetName `"$PrivateSubnetName`""

--- a/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/update_databricks_vnet.ps1
+++ b/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/update_databricks_vnet.ps1
@@ -1,0 +1,507 @@
+<#
+.SYNOPSIS
+    Updates an Azure Databricks workspace to use VNet Injection (or updates its VNet config) using Azure CLI and PowerShell.
+    Can be run from Azure Cloud Shell (PowerShell).
+
+.DESCRIPTION
+    This script exports the current ARM template of a Databricks workspace, modifies it to include VNet injection parameters,
+    removes legacy parameters, and redeploys it. Aligns with Microsoft Learn:
+    https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/update-workspaces
+
+    Before running: terminate all clusters and jobs; confirm the workspace is not on Azure Load Balancer (see documentation).
+
+.EXAMPLE
+    ./update_databricks_vnet.ps1 -WorkspaceId "/subscriptions/.../workspaces/my-ws" -VNetId "/subscriptions/.../virtualNetworks/my-vnet" -PublicSubnetName "pub-subnet" -PrivateSubnetName "priv-subnet"
+
+    If PublicSubnetName and/or PrivateSubnetName are omitted, the script lists the target VNet subnets and prompts for the missing values.
+#>
+
+param(
+    [Parameter(Mandatory = $true, HelpMessage = "Resource ID of the Databricks Workspace")]
+    [string]$WorkspaceId,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Resource ID of the target Virtual Network")]
+    [string]$VNetId,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Name of the Public Subnet")]
+    [string]$PublicSubnetName,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Name of the Private Subnet")]
+    [string]$PrivateSubnetName
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Warning @"
+Pre-flight (per Microsoft documentation): terminate all running clusters and jobs in the workspace; restart after the update completes.
+If the workspace uses Azure Load Balancer, contact your account team before migrating.
+"@
+
+# Check for Azure CLI
+if (-not (Get-Command "az" -ErrorAction SilentlyContinue)) {
+    Write-Error "Azure CLI ('az') is not installed or not in the path."
+    exit 1
+}
+
+function Get-ResourceIdSubscriptionId {
+    param([string]$ResourceId)
+
+    if ($ResourceId -match "^/?subscriptions/(?<subId>[^/]+)/") {
+        return $Matches['subId']
+    }
+
+    return $null
+}
+
+Write-Host "Parsing Workspace ID..." -ForegroundColor Cyan
+# Regex to extract components from Resource ID
+if ($WorkspaceId -match "^/?subscriptions/(?<subId>[^/]+)/resourceGroups/(?<rgName>[^/]+)/.+/workspaces/(?<wsName>[^/]+)$") {
+    $SubscriptionId = $Matches['subId']
+    $ResourceGroup = $Matches['rgName']
+    $WorkspaceName = $Matches['wsName']
+} else {
+    Write-Error "Invalid Workspace ID format."
+    exit 1
+}
+
+Write-Host "Subscription: $SubscriptionId"
+Write-Host "Resource Group: $ResourceGroup"
+Write-Host "Workspace: $WorkspaceName"
+
+# Set Subscription
+Write-Host "Setting active subscription..." -ForegroundColor Cyan
+az account set --subscription $SubscriptionId
+
+# Get Workspace Location for validation
+Write-Host "Getting Workspace details..." -ForegroundColor Cyan
+$wsDetails = az resource show --ids $WorkspaceId --output json | ConvertFrom-Json
+$wsLocation = $wsDetails.location
+
+function Test-WorkspaceUsesManagedVNet {
+    param([object]$WorkspaceResource)
+    $params = $WorkspaceResource.properties.parameters
+    if ($null -eq $params) { return $true }
+    $cvnProp = $params.PSObject.Properties['customVirtualNetworkId']
+    if ($null -eq $cvnProp) { return $true }
+    $valObj = $cvnProp.Value
+    if ($null -eq $valObj) { return $true }
+    $val = $valObj.value
+    return [string]::IsNullOrWhiteSpace([string]$val)
+}
+
+function Get-ManagedResourceGroupVnetPeerings {
+    param(
+        [string]$ManagedResourceGroupId,
+        [string]$SubscriptionId
+    )
+    $result = [System.Collections.Generic.List[object]]::new()
+    if ([string]::IsNullOrWhiteSpace($ManagedResourceGroupId)) { return $result }
+    if ($ManagedResourceGroupId -notmatch '/resourceGroups/([^/]+)$') { return $result }
+    $managedRg = $Matches[1]
+
+    $vnetJson = az network vnet list -g $managedRg --subscription $SubscriptionId -o json 2>$null
+    if ([string]::IsNullOrWhiteSpace($vnetJson)) { return $result }
+    $vnets = $vnetJson | ConvertFrom-Json
+    foreach ($v in @($vnets)) {
+        $peerJson = az network vnet peering list -g $managedRg --vnet-name $v.name --subscription $SubscriptionId -o json 2>$null
+        if ([string]::IsNullOrWhiteSpace($peerJson)) { continue }
+        $peers = $peerJson | ConvertFrom-Json
+        foreach ($p in @($peers)) {
+            $remoteId = $null
+            if ($p.remoteVirtualNetwork -and $p.remoteVirtualNetwork.id) {
+                $remoteId = $p.remoteVirtualNetwork.id
+            } elseif ($p.properties -and $p.properties.remoteVirtualNetwork -and $p.properties.remoteVirtualNetwork.id) {
+                $remoteId = $p.properties.remoteVirtualNetwork.id
+            }
+            $result.Add([PSCustomObject]@{
+                VNetName               = $v.name
+                PeeringName            = $p.name
+                RemoteVirtualNetworkId = $remoteId
+            })
+        }
+    }
+    return $result
+}
+
+Write-Host "Checking managed VNet / VNet peerings..." -ForegroundColor Cyan
+if (Test-WorkspaceUsesManagedVNet -WorkspaceResource $wsDetails) {
+    $mrgid = $wsDetails.properties.managedResourceGroupId
+    $peerings = Get-ManagedResourceGroupVnetPeerings -ManagedResourceGroupId $mrgid -SubscriptionId $SubscriptionId
+    if ($peerings.Count -gt 0) {
+        Write-Warning @"
+Found $($peerings.Count) VNet peering connection(s) on the workspace managed resource group VNet(s). Remove these managed VNet connections before migrating the workspace to VNet injection, then recreate the required connectivity on the target VNet after migration. See: https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/update-workspaces
+"@
+        $peerings | Format-Table -AutoSize | Out-String | Write-Host
+        Write-Error "Managed VNet peering connections must be removed before this migration can continue."
+        exit 1
+    } else {
+        Write-Host "No VNet peerings found on VNet(s) in the managed resource group (or no VNet listed there)." -ForegroundColor DarkGray
+    }
+} else {
+    Write-Host "Workspace already has customVirtualNetworkId set (VNet-injected). Skipping managed-VNet peering scan; if you are moving to another VNet, review peerings on your current VNet." -ForegroundColor DarkGray
+}
+
+# Validate VNet existence and Region
+Write-Host "Validating VNet existence and configuration..." -ForegroundColor Cyan
+$vnetValid = $false
+while (-not $vnetValid) {
+    $vnetSubscriptionId = Get-ResourceIdSubscriptionId -ResourceId $VNetId
+    if ([string]::IsNullOrWhiteSpace($vnetSubscriptionId)) {
+        Write-Warning "VNet ID '$VNetId' is not a valid Azure resource ID."
+        $VNetId = Read-Host "Please re-enter the valid VNet Resource ID"
+        continue
+    }
+
+    if ($vnetSubscriptionId -ne $SubscriptionId) {
+        Write-Warning "VNet subscription '$vnetSubscriptionId' does not match Workspace subscription '$SubscriptionId'."
+        $VNetId = Read-Host "Please re-enter a VNet Resource ID from the Workspace subscription"
+        continue
+    }
+
+    $vnetInfo = az network vnet show --ids $VNetId --output json 2>$null | ConvertFrom-Json
+    if (-not $vnetInfo) {
+        Write-Warning "VNet with ID '$VNetId' not found."
+        $VNetId = Read-Host "Please re-enter the valid VNet Resource ID"
+        continue
+    }
+    
+    # Check Region
+    if ($vnetInfo.location -ne $wsLocation) {
+        Write-Error "VNet region ($($vnetInfo.location)) does not match Workspace region ($wsLocation). VNet injection requires them to be in the same region."
+        exit 1
+    }
+
+    $vnetValid = $true
+}
+
+# Extract VNet name and Resource Group for subnet validation
+if ($VNetId -match "^/?subscriptions/[^/]+/resourceGroups/(?<rg>[^/]+)/.+/virtualNetworks/(?<name>[^/]+)$") {
+    $VNetRG = $Matches['rg']
+    $VNetName = $Matches['name']
+} else {
+    Write-Error "Invalid VNet ID format."
+    exit 1
+}
+
+# Helper function to prompt for a subnet when a subnet name was omitted
+function Select-SubnetName {
+    param (
+        [object[]]$Subnets,
+        [string]$Role,
+        [string]$ExcludedSubnetName
+    )
+
+    if (-not $Subnets -or $Subnets.Count -eq 0) {
+        Write-Error "No subnets found in the selected VNet."
+        exit 1
+    }
+
+    Write-Host ""
+    Write-Host "Available subnets for $Role subnet selection:" -ForegroundColor Cyan
+    for ($i = 0; $i -lt $Subnets.Count; $i++) {
+        $subnet = $Subnets[$i]
+        $delegations = @($subnet.delegations) | ForEach-Object {
+            if ($_.serviceName) { $_.serviceName }
+            elseif ($_.properties -and $_.properties.serviceName) { $_.properties.serviceName }
+        }
+        $delegationText = if ($delegations -and $delegations.Count -gt 0) { $delegations -join ", " } else { "None" }
+        $nsgText = if ($subnet.networkSecurityGroup -and $subnet.networkSecurityGroup.id) { "Yes" } else { "No" }
+        Write-Host ("[{0}] {1} | Prefix: {2} | Databricks delegation/other: {3} | NSG: {4}" -f ($i + 1), $subnet.name, $subnet.addressPrefix, $delegationText, $nsgText)
+    }
+
+    while ($true) {
+        $selection = Read-Host "Enter the number or name for the $Role subnet"
+        if ([string]::IsNullOrWhiteSpace($selection)) {
+            Write-Warning "A subnet selection is required."
+            continue
+        }
+
+        $selectedName = $null
+        $selectionNumber = 0
+        if ([int]::TryParse($selection, [ref]$selectionNumber)) {
+            if ($selectionNumber -ge 1 -and $selectionNumber -le $Subnets.Count) {
+                $selectedName = $Subnets[$selectionNumber - 1].name
+            }
+        } else {
+            $match = @($Subnets | Where-Object { $_.name -eq $selection })
+            if ($match.Count -eq 1) {
+                $selectedName = $match[0].name
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($selectedName)) {
+            Write-Warning "Invalid subnet selection '$selection'."
+            continue
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($ExcludedSubnetName) -and $selectedName -eq $ExcludedSubnetName) {
+            Write-Warning "The $Role subnet cannot be the same as '$ExcludedSubnetName'. Choose a different subnet."
+            continue
+        }
+
+        return $selectedName
+    }
+}
+
+# Helper function for subnet validation
+function Validate-Subnet {
+    param (
+        [string]$SubnetName,
+        [string]$VNetRG,
+        [string]$VNetName,
+        [string]$Role
+    )
+    
+    $subnetInfo = az network vnet subnet show --resource-group $VNetRG --vnet-name $VNetName --name $SubnetName --output json 2>$null | ConvertFrom-Json
+    
+    if (-not $subnetInfo) {
+        Write-Warning "$Role Subnet '$SubnetName' not found in VNet '$VNetName'."
+        return $null
+    }
+
+    # Check Delegation
+    $hasDelegation = $false
+    
+    # Ensure delegations is treated as an array even if single object
+    $delegations = @($subnetInfo.delegations)
+    
+    if ($delegations -and $delegations.Count -gt 0) {
+        foreach ($del in $delegations) {
+            # Try various property paths to find serviceName
+            $serviceName = $null
+            
+            if ($del.properties -and $del.properties.serviceName) {
+                $serviceName = $del.properties.serviceName
+            } elseif ($del.serviceName) {
+                $serviceName = $del.serviceName
+            } elseif ($del.PSObject.Properties['properties'] -and $del.PSObject.Properties['properties'].Value.serviceName) {
+                $serviceName = $del.PSObject.Properties['properties'].Value.serviceName
+            }
+            
+            if ($serviceName -eq "Microsoft.Databricks/workspaces") {
+                $hasDelegation = $true
+                break
+            }
+        }
+    }
+
+    if (-not $hasDelegation) {
+        $found = if ($subnetInfo.delegations) { 
+             $subnetInfo.delegations | ForEach-Object { 
+                if ($_.properties.serviceName) { $_.properties.serviceName } 
+                elseif ($_.PSObject.Properties['properties'].Value.serviceName) { $_.PSObject.Properties['properties'].Value.serviceName }
+             }
+        } else { "None" }
+        Write-Error "Subnet '$SubnetName' is missing the required delegation to 'Microsoft.Databricks/workspaces'. Found: $($found -join ', ')"
+        exit 1
+    }
+
+    # Check NSG Association
+    if (-not $subnetInfo.networkSecurityGroup.id) {
+        Write-Error "Subnet '$SubnetName' does not have a Network Security Group (NSG) associated. A security group is required."
+        exit 1
+    }
+
+    return $subnetInfo
+}
+
+Write-Host "Loading target VNet subnets..." -ForegroundColor Cyan
+$subnetsJson = az network vnet subnet list --resource-group $VNetRG --vnet-name $VNetName --output json
+$subnets = @($subnetsJson | ConvertFrom-Json)
+
+if ([string]::IsNullOrWhiteSpace($PublicSubnetName)) {
+    $PublicSubnetName = Select-SubnetName -Subnets $subnets -Role "Public" -ExcludedSubnetName $PrivateSubnetName
+}
+
+if ([string]::IsNullOrWhiteSpace($PrivateSubnetName)) {
+    $PrivateSubnetName = Select-SubnetName -Subnets $subnets -Role "Private" -ExcludedSubnetName $PublicSubnetName
+}
+
+if ($PublicSubnetName -eq $PrivateSubnetName) {
+    Write-Error "PublicSubnetName and PrivateSubnetName must be different subnets."
+    exit 1
+}
+
+# Validate Public Subnet
+Write-Host "Validating Public Subnet..." -ForegroundColor Cyan
+while (-not (Validate-Subnet -SubnetName $PublicSubnetName -VNetRG $VNetRG -VNetName $VNetName -Role "Public")) {
+    $PublicSubnetName = Read-Host "Please re-enter the valid Public Subnet Name"
+    if ($PublicSubnetName -eq $PrivateSubnetName) {
+        Write-Error "PublicSubnetName and PrivateSubnetName must be different subnets."
+        exit 1
+    }
+}
+
+# Validate Private Subnet
+Write-Host "Validating Private Subnet..." -ForegroundColor Cyan
+while (-not (Validate-Subnet -SubnetName $PrivateSubnetName -VNetRG $VNetRG -VNetName $VNetName -Role "Private")) {
+    $PrivateSubnetName = Read-Host "Please re-enter the valid Private Subnet Name"
+    if ($PublicSubnetName -eq $PrivateSubnetName) {
+        Write-Error "PublicSubnetName and PrivateSubnetName must be different subnets."
+        exit 1
+    }
+}
+
+# Export Template
+Write-Host "Exporting current ARM template..." -ForegroundColor Cyan
+$TemplateFile = "exported_template.json"
+$ModifiedFile = "modified_template.json"
+$ExportErrorFile = "export_errors.txt"
+
+if (Test-Path $ExportErrorFile) {
+    Remove-Item -Path $ExportErrorFile -Force
+}
+
+az group export --resource-group $ResourceGroup --resource-ids $WorkspaceId --output json 1> $TemplateFile 2> $ExportErrorFile
+$exportExitCode = $LASTEXITCODE
+
+$exportErrors = ""
+if (Test-Path $ExportErrorFile) {
+    $exportErrors = Get-Content -Path $ExportErrorFile -Raw
+}
+
+$privateEndpointExportWarning = "Could not get resources of the type 'Microsoft.Databricks/workspaces/privateEndpointConnections'"
+$nonIgnoredExportErrors = @()
+if (-not [string]::IsNullOrWhiteSpace($exportErrors)) {
+    $nonIgnoredExportErrors = @($exportErrors -split "`r?`n" | Where-Object {
+        -not [string]::IsNullOrWhiteSpace($_) -and
+        $_ -notmatch [regex]::Escape($privateEndpointExportWarning) -and
+        $_ -notmatch "Resources of this type will not be exported"
+    })
+}
+$hasPrivateEndpointExportWarning = (-not [string]::IsNullOrWhiteSpace($exportErrors)) -and ($exportErrors -match [regex]::Escape($privateEndpointExportWarning))
+
+if ($exportExitCode -ne 0 -and $nonIgnoredExportErrors.Count -gt 0) {
+    Write-Error "Failed to export template. Azure CLI error: $exportErrors"
+    exit 1
+}
+
+if ($hasPrivateEndpointExportWarning) {
+    Write-Host "Ignoring Azure export warning for Databricks privateEndpointConnections; those child resources are not needed for this migration." -ForegroundColor DarkGray
+}
+
+if (Test-Path $ExportErrorFile) {
+    Remove-Item -Path $ExportErrorFile -Force
+}
+
+if (-not (Test-Path $TemplateFile) -or (Get-Item $TemplateFile).Length -eq 0) {
+    Write-Error "Failed to export template."
+    exit 1
+}
+
+# Modify JSON using PowerShell
+Write-Host "Modifying template for VNet injection..." -ForegroundColor Cyan
+
+try {
+    $json = Get-Content -Path $TemplateFile -Raw | ConvertFrom-Json
+
+    # Locate the Databricks workspace resource
+    $resources = $json.resources
+    $json.resources = @($resources | Where-Object { $_.type -ne "Microsoft.Databricks/workspaces/privateEndpointConnections" })
+    $resources = $json.resources
+    $found = $false
+
+    foreach ($res in $resources) {
+        if ($res.type -eq "Microsoft.Databricks/workspaces") {
+            $found = $true
+            
+            # API version required for this migration path (Microsoft Learn: Update workspace network configuration)
+            $res.apiVersion = "2026-01-01"
+
+            # Remove legacy parameters from properties.parameters if they exist (per Microsoft documentation)
+            $legacyProps = @("vnetAddressPrefix", "natGatewayName", "publicIpName")
+            if ($res.properties.parameters) {
+                foreach ($prop in $legacyProps) {
+                    if ($res.properties.parameters.PSObject.Properties.Match($prop)) {
+                        $res.properties.parameters.PSObject.Properties.Remove($prop)
+                    }
+                }
+            }
+
+            # Remove read-only provisioningState
+            if ($res.properties.PSObject.Properties.Match("provisioningState")) {
+                $res.properties.PSObject.Properties.Remove("provisioningState")
+            }
+
+            # Ensure parameters object exists
+            if (-not $res.properties.parameters) {
+                $res.properties | Add-Member -MemberType NoteProperty -Name "parameters" -Value ([PSCustomObject]@{})
+            }
+
+            # Add/Update VNet Injection parameters
+            # Note: We use Add-Member -Force to overwrite if exists or just standard assignment
+            # Using a helper object to construct the parameter structure expected by ARM: { "value": "..." }
+            
+            $res.properties.parameters | Add-Member -MemberType NoteProperty -Name "customVirtualNetworkId" -Value ([PSCustomObject]@{ value = $VNetId }) -Force
+            $res.properties.parameters | Add-Member -MemberType NoteProperty -Name "customPublicSubnetName" -Value ([PSCustomObject]@{ value = $PublicSubnetName }) -Force
+            $res.properties.parameters | Add-Member -MemberType NoteProperty -Name "customPrivateSubnetName" -Value ([PSCustomObject]@{ value = $PrivateSubnetName }) -Force
+        }
+    }
+
+    if (-not $found) {
+        Write-Error "Could not find Microsoft.Databricks/workspaces resource in the exported template."
+        exit 1
+    }
+
+    # Save modified JSON
+    $json | ConvertTo-Json -Depth 100 | Set-Content -Path $ModifiedFile
+}
+catch {
+    Write-Error "Error processing JSON: $_"
+    exit 1
+}
+
+# Parameters Handling
+# When exporting, some parameters might be parameterized in the ARM template but not have default values in the 'parameters' section.
+# We need to ensure we pass the workspace name if it was parameterized.
+
+$deploymentParams = @()
+if ($json.parameters -and $json.parameters.PSObject.Properties.Match("workspaceName")) {
+   # Check if it lacks a default value
+   if (-not $json.parameters.workspaceName.defaultValue) {
+       $deploymentParams += "--parameters workspaceName=$WorkspaceName"
+   }
+}
+# Also check for any other parameters that look like the workspace name parameter that the user mentioned
+# The export command often auto-generates parameter names like "workspaces_name_name"
+
+# To be safe, we can try to detect parameters that don't have default values and see if we can fill them, 
+# but for now, let's just use the --parameters argument if we detect the standard pattern or pass the template as-is 
+# and let the user interact if needed. But since this is a script, we should try to automate.
+
+# BETTER APPROACH:
+# We will inspect the 'parameters' section of the exported JSON.
+# Any parameter that does NOT have a 'defaultValue' needs to be supplied.
+# We know 'workspaceName' is likely one of them.
+
+$paramsToPass = @{}
+
+if ($json.parameters) {
+    foreach ($paramName in $json.parameters.PSObject.Properties.Name) {
+        $paramObj = $json.parameters.$paramName
+        if (-not $paramObj.defaultValue) {
+            # Try to guess the value based on name
+            if ($paramName -like "*workspace*" -or $paramName -like "*name*") {
+                $paramsToPass[$paramName] = $WorkspaceName
+            }
+        }
+    }
+}
+
+$paramArgs = @()
+foreach ($key in $paramsToPass.Keys) {
+    $paramArgs += "--parameters"
+    $paramArgs += "$key=$($paramsToPass[$key])"
+}
+
+# Deploy
+Write-Host "Deploying updated template..." -ForegroundColor Cyan
+az deployment group create `
+    --resource-group $ResourceGroup `
+    --name "vnet-update-deployment-$(Get-Date -Format 'yyyyMMddHHmm')" `
+    --template-file $ModifiedFile `
+    --mode Incremental `
+    @paramArgs
+
+Write-Host "Deployment initiated successfully." -ForegroundColor Green
+


### PR DESCRIPTION
## Description
Adds `workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/` — PowerShell automation to convert an Azure Databricks workspace from a managed VNet to VNet injection (and an optional helper script that provisions a Databricks-ready VNet).

This follows the [Microsoft Learn guidance](https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/update-workspaces) for the workspace network update path (Terraform is not supported for this flow, so the scripts use `az` + ARM export/deploy).

## Category
- [x] workspace-setup

## Type of Change
- [x] New project

## Project Details
**Project Name:** managed-vnet-to-vnet-injection
**Purpose:** Automate the in-place conversion of an Azure Databricks workspace from a managed VNet to a customer-managed VNet (VNet injection), including pre-flight validation and rollback-friendly considerations.
**Technologies Used:** PowerShell, Azure CLI (`az`), ARM templates

## Contents
- `README.md` — prerequisites, important considerations (permissions, downtime, Private Link, subnet usage), usage, script features, and post-deployment validation steps.
- `create_databricks_vnet.ps1` — optional helper that creates a compliant VNet (RG, VNet, public/private subnets, NSGs, `Microsoft.Databricks/workspaces` delegation).
- `update_databricks_vnet.ps1` — validates the target VNet/subnets, exports the workspace ARM template, rewrites it for VNet injection (apiVersion `2026-01-01`, sets `customVirtualNetworkId` / `customPublicSubnetName` / `customPrivateSubnetName`, removes legacy `vnetAddressPrefix` / `natGatewayName` / `publicIpName` parameters), and redeploys.

## Testing
- [x] Code runs without errors
- [x] Documentation is complete
- [x] Used only synthetic data

## Security Compliance
- [x] No customer data, PII, or proprietary information
- [x] No credentials or access tokens
- [x] Only synthetic data used
- [x] Third-party licenses acknowledged

---

**By submitting this PR, I confirm I have followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and security requirements.**

This pull request and its description were written by Isaac.