### PR TITLE
Add optional NAT gateway for outbound connectivity to VNet script

### DIFF
--- a/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/create_databricks_vnet.ps1
+++ b/workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/create_databricks_vnet.ps1
@@ -7,6 +7,17 @@
     Both subnets are associated with Network Security Groups and delegated to Microsoft.Databricks/workspaces.
     Created resources are tagged with owner=<current Azure CLI user>.
 
+    Outbound connectivity:
+      The script asks whether a NAT gateway is required for outbound internet access. If yes, it creates a
+      Standard SKU static public IP, creates the NAT gateway, and associates it with both subnets. If no,
+      it emits an alert: Azure's default outbound access has been retired, so you MUST provide an explicit
+      outbound method (NAT gateway, Azure Firewall, a user-defined route to an NVA, or load balancer outbound
+      rules) before Databricks clusters can reach the control plane.
+
+    All inputs can be supplied as parameters up front (non-interactive) OR left out, in which case the script
+    prompts for each value (with sensible defaults). This includes the NAT gateway decision: pass
+    -CreateNatGateway $true/$false to run unattended, or omit it to be asked.
+
     If CIDR values are not supplied, these defaults are used:
       VNet:           10.0.0.0/16
       Public subnet:  10.0.1.0/24
@@ -17,6 +28,14 @@
 
 .EXAMPLE
     ./create_databricks_vnet.ps1 -ResourceGroupName "rg-databricks-network" -Location "eastus" -VNetName "adb-vnet" -VNetCidr "10.20.0.0/16" -PublicSubnetCidr "10.20.1.0/24" -PrivateSubnetCidr "10.20.2.0/24"
+
+.EXAMPLE
+    # Fully non-interactive, with a NAT gateway for outbound connectivity
+    ./create_databricks_vnet.ps1 -ResourceGroupName "rg-databricks-network" -Location "eastus" -CreateNatGateway $true
+
+.EXAMPLE
+    # Fully non-interactive, no NAT gateway (you will provide your own outbound method)
+    ./create_databricks_vnet.ps1 -ResourceGroupName "rg-databricks-network" -Location "eastus" -CreateNatGateway $false
 #>
 
 param(
@@ -43,7 +62,16 @@ param(
     [string]$PrivateSubnetName,
 
     [Parameter(Mandatory = $false, HelpMessage = "Address range for the private subnet")]
-    [string]$PrivateSubnetCidr
+    [string]$PrivateSubnetCidr,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Create a NAT gateway for outbound connectivity. Omit to be prompted; pass `$true/`$false to run unattended.")]
+    [Nullable[bool]]$CreateNatGateway,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Name of the NAT gateway to create (only used when a NAT gateway is requested)")]
+    [string]$NatGatewayName,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Name of the public IP for the NAT gateway (only used when a NAT gateway is requested)")]
+    [string]$NatPublicIpName
 )
 
 $ErrorActionPreference = "Stop"
@@ -92,6 +120,25 @@ function Read-ValueWithDefault {
     }
 
     return $value
+}
+
+function Read-YesNo {
+    param(
+        [string]$Prompt,
+        [Nullable[bool]]$CurrentValue
+    )
+
+    # Honor a value supplied as a parameter (non-interactive run).
+    if ($null -ne $CurrentValue) {
+        return [bool]$CurrentValue
+    }
+
+    do {
+        $value = (Read-Host "$Prompt [y/n]").Trim().ToLowerInvariant()
+        if ($value -in @("y", "yes")) { return $true }
+        if ($value -in @("n", "no")) { return $false }
+        Write-Warning "Please answer 'y' (yes) or 'n' (no)."
+    } while ($true)
 }
 
 function Assert-LastCommandSucceeded {
@@ -146,6 +193,13 @@ $PublicSubnetName = Read-ValueWithDefault -Prompt "Public subnet name" -CurrentV
 $PublicSubnetCidr = Read-ValueWithDefault -Prompt "Public subnet CIDR" -CurrentValue $PublicSubnetCidr -DefaultValue $DefaultPublicSubnetCidr
 $PrivateSubnetName = Read-ValueWithDefault -Prompt "Private subnet name" -CurrentValue $PrivateSubnetName -DefaultValue $DefaultPrivateSubnetName
 $PrivateSubnetCidr = Read-ValueWithDefault -Prompt "Private subnet CIDR" -CurrentValue $PrivateSubnetCidr -DefaultValue $DefaultPrivateSubnetCidr
+
+# Outbound connectivity decision (parameter up front, or prompt here).
+$CreateNat = Read-YesNo -Prompt "Create a NAT gateway for outbound internet connectivity?" -CurrentValue $CreateNatGateway
+if ($CreateNat) {
+    $NatGatewayName = Read-ValueWithDefault -Prompt "NAT gateway name" -CurrentValue $NatGatewayName -DefaultValue "$VNetName-nat"
+    $NatPublicIpName = Read-ValueWithDefault -Prompt "NAT gateway public IP name" -CurrentValue $NatPublicIpName -DefaultValue "$VNetName-nat-pip"
+}
 
 if ($PublicSubnetName -eq $PrivateSubnetName) {
     Write-Error "PublicSubnetName and PrivateSubnetName must be different."
@@ -232,6 +286,74 @@ az network vnet subnet create `
     --output none
 Assert-LastCommandSucceeded "Failed to create private subnet '$PrivateSubnetName'."
 
+# -----------------------------------------------------------------------------
+# Outbound connectivity: NAT gateway (optional)
+# -----------------------------------------------------------------------------
+if ($CreateNat) {
+    Write-Host ""
+    Write-Host "Configuring outbound connectivity via NAT gateway..." -ForegroundColor Cyan
+
+    # Public IP for the NAT gateway (Standard SKU, static — required by NAT gateway).
+    if (-not (Test-AzCliResourceExists { az network public-ip show --resource-group $ResourceGroupName --name $NatPublicIpName --output none })) {
+        Write-Host "Creating public IP '$NatPublicIpName' (Standard, Static)..." -ForegroundColor Cyan
+        az network public-ip create `
+            --resource-group $ResourceGroupName `
+            --name $NatPublicIpName `
+            --location $Location `
+            --sku Standard `
+            --allocation-method Static `
+            --tags owner=$OwnerTagValue `
+            --output none
+        Assert-LastCommandSucceeded "Failed to create public IP '$NatPublicIpName'."
+    } else {
+        Write-Host "Public IP '$NatPublicIpName' already exists." -ForegroundColor DarkGray
+        $natPip = az network public-ip show --resource-group $ResourceGroupName --name $NatPublicIpName --output json | ConvertFrom-Json
+        Assert-LastCommandSucceeded "Failed to read public IP '$NatPublicIpName'."
+        Set-OwnerTag -ResourceId $natPip.id -Owner $OwnerTagValue
+    }
+
+    # NAT gateway.
+    if (-not (Test-AzCliResourceExists { az network nat gateway show --resource-group $ResourceGroupName --name $NatGatewayName --output none })) {
+        Write-Host "Creating NAT gateway '$NatGatewayName'..." -ForegroundColor Cyan
+        az network nat gateway create `
+            --resource-group $ResourceGroupName `
+            --name $NatGatewayName `
+            --location $Location `
+            --public-ip-addresses $NatPublicIpName `
+            --idle-timeout 10 `
+            --tags owner=$OwnerTagValue `
+            --output none
+        Assert-LastCommandSucceeded "Failed to create NAT gateway '$NatGatewayName'."
+    } else {
+        Write-Host "NAT gateway '$NatGatewayName' already exists." -ForegroundColor DarkGray
+        $natGw = az network nat gateway show --resource-group $ResourceGroupName --name $NatGatewayName --output json | ConvertFrom-Json
+        Assert-LastCommandSucceeded "Failed to read NAT gateway '$NatGatewayName'."
+        Set-OwnerTag -ResourceId $natGw.id -Owner $OwnerTagValue
+    }
+
+    # Associate the NAT gateway with both subnets. With Secure Cluster Connectivity,
+    # cluster nodes run in the private subnet too, so both need the outbound path.
+    foreach ($subnet in @($PublicSubnetName, $PrivateSubnetName)) {
+        Write-Host "Associating NAT gateway '$NatGatewayName' with subnet '$subnet'..." -ForegroundColor Cyan
+        az network vnet subnet update `
+            --resource-group $ResourceGroupName `
+            --vnet-name $VNetName `
+            --name $subnet `
+            --nat-gateway $NatGatewayName `
+            --output none
+        Assert-LastCommandSucceeded "Failed to associate NAT gateway '$NatGatewayName' with subnet '$subnet'."
+    }
+} else {
+    Write-Host ""
+    Write-Warning ("No NAT gateway was created. Azure default outbound access for new deployments is retired, so " +
+        "this VNet has NO outbound internet path. Databricks clusters require outbound connectivity to the control " +
+        "plane. Before launching a workspace you MUST attach an explicit outbound method to the subnets, for example:")
+    Write-Host "  - A NAT gateway (re-run this script and answer 'y', or pass -CreateNatGateway `$true)" -ForegroundColor Yellow
+    Write-Host "  - Azure Firewall or another NVA with a user-defined route (UDR)" -ForegroundColor Yellow
+    Write-Host "  - Outbound rules on a Standard Load Balancer" -ForegroundColor Yellow
+    Write-Host "  Reference: https://learn.microsoft.com/azure/virtual-network/ip-services/default-outbound-access" -ForegroundColor Yellow
+}
+
 $vnet = az network vnet show --resource-group $ResourceGroupName --name $VNetName --output json | ConvertFrom-Json
 Assert-LastCommandSucceeded "Failed to read VNet '$VNetName' after creation."
 
@@ -240,6 +362,11 @@ Write-Host "Databricks-ready VNet created successfully." -ForegroundColor Green
 Write-Host "VNet ID: $($vnet.id)"
 Write-Host "Public subnet: $PublicSubnetName ($PublicSubnetCidr)"
 Write-Host "Private subnet: $PrivateSubnetName ($PrivateSubnetCidr)"
+if ($CreateNat) {
+    Write-Host "NAT gateway: $NatGatewayName (public IP '$NatPublicIpName') associated with both subnets ('$PublicSubnetName', '$PrivateSubnetName')"
+} else {
+    Write-Host "NAT gateway: NOT created — attach an outbound method before launching clusters (see warning above)." -ForegroundColor Yellow
+}
 Write-Host ""
 Write-Host "Use this with update_databricks_vnet.ps1:" -ForegroundColor Cyan
 Write-Host "./update_databricks_vnet.ps1 -WorkspaceId `"<workspace-resource-id>`" -VNetId `"$($vnet.id)`" -PublicSubnetName `"$PublicSubnetName`" -PrivateSubnetName `"$PrivateSubnetName`""


### PR DESCRIPTION
## What

Extends `workspace-setup/powershell-examples/managed-vnet-to-vnet-injection/create_databricks_vnet.ps1` with an optional NAT gateway step for outbound internet connectivity.

## Changes

- **NAT gateway decision** — the script now asks `Create a NAT gateway for outbound internet connectivity? [y/n]`, or accepts `-CreateNatGateway $true/$false` to run unattended (uses `[Nullable[bool]]` so "omitted" can be distinguished from an explicit `$false`).
- **If yes** — creates a Standard SKU static public IP, creates the NAT gateway, and associates it with **both** the public and private subnets (cluster nodes run in both under Secure Cluster Connectivity, so both need the outbound path).
- **If no** — emits an alert that Azure default outbound access is retired and an explicit outbound method (NAT gateway, Azure Firewall/NVA + UDR, or Standard LB outbound rules) must be attached before launching clusters, with a link to the Microsoft doc.
- New `NatGatewayName` / `NatPublicIpName` inputs are param-or-prompt with sensible defaults (`<vnet>-nat`, `<vnet>-nat-pip`).
- New resources follow the existing idempotency checks (`Test-AzCliResourceExists`) and `owner` tagging conventions; added a `Read-YesNo` helper matching the existing prompt helpers.
- Updated comment-based help (`.DESCRIPTION`, two `.EXAMPLE` blocks) and the final summary output.

The change is additive (+128/−1); existing parameter and prompt behavior is unchanged.

This pull request and its description were written by Isaac.