### PR TITLE
Add SDP schema evolution demo to data-engineering

### DIFF
--- a/data-engineering/README.md
+++ b/data-engineering/README.md
@@ -1,1 +1,7 @@
 # Data Engineering
+
+## Projects
+
+### [SDP Schema Evolution (Rescued Data Column)](./sdp-evolution/)
+
+An agent-runnable Databricks Asset Bundle demo that handles schema evolution - column renames, type changes, and new columns - in Spark Declarative Pipelines using Auto Loader rescue mode and silver reconciliation via `_rescued_data`, with no full refresh.

--- a/data-engineering/sdp-evolution/.gitignore
+++ b/data-engineering/sdp-evolution/.gitignore
@@ -1,0 +1,5 @@
+# Dot-directories (local tooling, caches, IDE, agent scratch)
+.*/
+
+__pycache__/
+*.pyc

--- a/data-engineering/sdp-evolution/README.md
+++ b/data-engineering/sdp-evolution/README.md
@@ -1,0 +1,277 @@
+# SDP Schema Evolution with the Rescued Data Column
+
+Agent runbook for an AI coding harness (Cursor, Claude Code, Codex, etc.).
+A customer should be able to open this project and say: **run README.md**.
+Follow every step in order.
+Do not skip pauses.
+Do not invent credentials or workspace settings.
+
+## What this demo teaches
+
+Bronze uses a fixed schema and Auto Loader `schemaEvolutionMode = rescue`.
+Column renames, type changes, and new columns land in `_rescued_data` instead of breaking the stream.
+Silver recovers those values with `reconcile` (`coalesce` against rescued JSON).
+No full refresh.
+No bronze/silver drift.
+
+Rule to remember: **fixed bronze schema -> rescue everything -> reconcile in silver -> never full-refresh.**
+
+## Agent operating rules
+
+1. Use only the CLI flags the user confirmed in Prerequisites.
+2. After every `databricks bundle run` / `deploy`, wait for SUCCESS before the next step.
+3. On failure: read the error, fix local code or config, redeploy if needed, re-run the failed command.
+   Do not continue to the next demo step until the current one is green.
+4. When this runbook says **PAUSE**, stop.
+   Message the user with the exact SQL (or UI action) below.
+   Wait for them to reply before continuing.
+5. Do not flip the Step 4 reconcile toggle until that step says to.
+6. Prefer the Databricks CLI over clicking around the workspace UI, except for SQL verification pauses (SQL editor).
+
+## Prerequisites (configure before anything else)
+
+**PAUSE.**
+Do not deploy yet.
+Ask the user to confirm these three values.
+They are mandatory.
+
+| Setting | Where it lives | Example |
+| --- | --- | --- |
+| **CLI profile** | Databricks CLI auth profile name | `my-profile` |
+| **Catalog name** | `variables.catalog.default` in `databricks.yml` | `main` |
+| **Workspace URL** | `targets.dev.workspace.host` in `databricks.yml` | `https://YOUR_WORKSPACE.cloud.databricks.com/` |
+
+Also confirm:
+
+- The user can already authenticate with that profile (`databricks auth login --profile <PROFILE>` if needed).
+- Unity Catalog is enabled and they can create a schema + volume in that catalog.
+- Serverless compute is enabled.
+- Schema name (default `sdp_evolution` via `variables.schema.default`) is acceptable, or they want a different one.
+
+Then update `databricks.yml` if their values differ from the defaults/examples above.
+
+Every bundle command in this runbook uses:
+
+```bash
+databricks bundle <deploy|run|validate> --profile <PROFILE> --target dev
+```
+
+Substitute `<PROFILE>` with the confirmed profile.
+Substitute `<CATALOG>` and `<SCHEMA>` in SQL with the confirmed catalog and schema.
+
+**Do not continue until the user has confirmed profile, catalog name, and workspace URL.**
+
+## Layout (read-only context)
+
+| Path | Role |
+| --- | --- |
+| `databricks.yml` | Bundle: catalog/schema vars, workspace host, targets. |
+| `resources/uc.yml` | UC schema + managed `landing` volume (created on deploy). |
+| `resources/pipeline.yml` | Serverless SDP pipeline. |
+| `resources/seed_jobs.yml` | `seed_v1_job` / `seed_v2_job`. |
+| `resources/test_job.yml` | Unit-test notebook job. |
+| `src/pipeline.py` | Bronze (rescue) + silver (STATE 1 passthrough / STATE 2 reconcile). |
+| `src/reconcile.py` | Pure `reconcile(df)`. |
+| `src/seed_data.py` | Writes JSON into the landing volume (does not create UC objects). |
+| `tests/test_reconcile_notebook.py` | Assert-based reconcile tests. |
+
+Shipped silver state for a fresh run must be **STATE 1**: passthrough `return df.select(...)` is live; `return reconcile(df)` is inactive.
+If a previous run left STATE 2 active, restore STATE 1 before Step 0 (unwrap the passthrough from the triple-quoted block and comment out or remove the active `return reconcile(df)`).
+
+---
+
+## Step 0: validate and deploy
+
+```bash
+databricks bundle validate --profile <PROFILE> --target dev
+databricks bundle deploy --profile <PROFILE> --target dev
+```
+
+Deploy creates the UC schema and managed `landing` volume, plus jobs and the pipeline.
+Expected: `Validation OK!` then `Deployment complete!`
+
+---
+
+## Step 1: run the unit-test gate
+
+```bash
+databricks bundle run test_job --profile <PROFILE> --target dev
+```
+
+Expected: job `TERMINATED SUCCESS`.
+Any failed assert fails the job.
+
+---
+
+## Step 2: seed clean v1 data
+
+```bash
+databricks bundle run seed_v1_job --profile <PROFILE> --target dev
+```
+
+Expected: SUCCESS and a log line writing `orders_v1.json` under:
+
+```text
+/Volumes/<CATALOG>/<SCHEMA>/<landing-volume>/orders
+```
+
+v1 shape: `order_id`, `cust_name`, `amount` (string), `order_ts`.
+
+---
+
+## Step 3: baseline pipeline (v1 only)
+
+```bash
+databricks bundle run orders_pipeline --profile <PROFILE> --target dev
+```
+
+Expected: pipeline update COMPLETED / SUCCESS.
+
+### PAUSE - verify baseline data
+
+Before you continue, tell the user:
+
+> Go to the SQL editor in workspace `<WORKSPACE_URL>`.
+> Run the queries below.
+> Confirm bronze has rows with `_rescued_data` null, and silver has populated `customer_name` / `amount` with `loyalty_tier` null.
+> Come back after you verified that and tell me to continue.
+
+```sql
+SELECT * FROM <CATALOG>.<SCHEMA>.orders_bronze ORDER BY order_id;
+-- Expect: rows present; _rescued_data is null for v1.
+
+SELECT * FROM <CATALOG>.<SCHEMA>.orders_silver ORDER BY order_id;
+-- Expect: customer_name + amount populated; loyalty_tier null.
+```
+
+**Do not start Step 4 until the user confirms the baseline looks correct.**
+
+---
+
+## Step 4: introduce schema drift (v2)
+
+```bash
+databricks bundle run seed_v2_job --profile <PROFILE> --target dev
+```
+
+Expected: SUCCESS writing `orders_v2.json` with three drifts vs v1:
+
+1. Rename: `cust_name` -> `customer_name`
+2. Type change: `amount` string -> number
+3. New column: `loyalty_tier`
+
+---
+
+## Step 5: re-run pipeline and observe the break (still STATE 1)
+
+```bash
+databricks bundle run orders_pipeline --profile <PROFILE> --target dev
+```
+
+Expected: pipeline SUCCESS (ingest does not crash).
+Drift is rescued, not fatal.
+
+### PAUSE - verify rescued / broken silver
+
+Before you continue, tell the user:
+
+> Go to the SQL editor.
+> Run the queries below.
+> Confirm new v2 bronze rows have values in `_rescued_data`, and silver shows null `customer_name` / `amount` for those v2 rows.
+> Come back after you verified that and tell me to continue.
+
+```sql
+SELECT order_id, cust_name, amount, _rescued_data
+FROM <CATALOG>.<SCHEMA>.orders_bronze
+WHERE _rescued_data IS NOT NULL
+ORDER BY order_id;
+-- Expect: v2 rows; cust_name/amount null in base columns; JSON in _rescued_data.
+
+SELECT * FROM <CATALOG>.<SCHEMA>.orders_silver ORDER BY order_id;
+-- Expect: v1 rows still fine; v2 rows have null customer_name / amount.
+```
+
+**Do not apply the reconcile fix until the user confirms they saw the break.**
+
+---
+
+## Step 6: apply the reconcile fix in `src/pipeline.py` (STATE 2)
+
+Open `src/pipeline.py`, find `orders_silver` (section marked `STEP 4`).
+
+Disable STATE 1 by wrapping the passthrough return in a triple-quoted string:
+
+```python
+    # START OF STATE 1
+    """
+    return df.select(
+        "order_id",
+        F.col("cust_name").alias("customer_name"),
+        F.col("amount").cast("double").alias("amount"),
+        F.lit(None).cast("string").alias("loyalty_tier"),
+        "order_ts",
+    )"""
+    # END OF STATE 1
+```
+
+Activate STATE 2 by making this the live return:
+
+```python
+    # START OF STATE 2
+    return reconcile(df)
+    # END OF STATE 2
+```
+
+Do not deploy yet.
+
+### PAUSE - user continues after the code change
+
+Tell the user:
+
+> I wrapped the STATE 1 passthrough return in triple quotes and activated `return reconcile(df)`.
+> Reply **continue** when you want me to deploy and re-run the pipeline.
+
+**Do not deploy or run until the user says to continue.**
+
+---
+
+## Step 7: redeploy and re-run (reconcile on)
+
+```bash
+databricks bundle deploy --profile <PROFILE> --target dev
+databricks bundle run orders_pipeline --profile <PROFILE> --target dev
+```
+
+Expected: deploy complete, pipeline SUCCESS.
+Bronze is not fully refreshed; silver recomputes with reconcile.
+
+### PAUSE - verify silver recovered
+
+Before you declare the demo done, tell the user:
+
+> Go to the SQL editor one last time.
+> Run the query below.
+> Confirm every row has `customer_name` and `amount`, and v2 rows also have `loyalty_tier`.
+> Come back after you verified that.
+
+```sql
+SELECT * FROM <CATALOG>.<SCHEMA>.orders_silver ORDER BY order_id;
+-- Expect: all rows recovered; v2 rows carry loyalty_tier; no full refresh of bronze required.
+```
+
+When the user confirms, the demo is complete.
+
+---
+
+## Why this avoids full recomputes
+
+- Bronze keeps a fixed schema, so drift does not force a bronze rewrite.
+- Drift is preserved in `_rescued_data`, so nothing is lost.
+- Reconciliation runs in silver (materialized view) only.
+- Old and new rows share business columns via `coalesce`.
+
+## Applying this across a pipeline portfolio
+
+1. Fixed bronze schema + `schemaEvolutionMode = rescue` + `rescuedDataColumn = _rescued_data`.
+2. Small `reconcile`-style function per silver table.
+3. On source drift, update only the reconcile mapping - no full refresh, no downtime.

--- a/data-engineering/sdp-evolution/databricks.yml
+++ b/data-engineering/sdp-evolution/databricks.yml
@@ -1,0 +1,28 @@
+bundle:
+  name: sdp-evolution
+
+experimental:
+  skip_name_prefix_for_schema: true
+
+variables:
+  catalog:
+    description: UC catalog for the demo (set to your catalog before deploy)
+    default: main
+  schema:
+    description: UC schema for the demo
+    default: sdp_evolution
+
+include:
+  - resources/*.yml
+
+targets:
+  dev:
+    mode: development
+    default: true
+    workspace:
+      host: https://YOUR_WORKSPACE.cloud.databricks.com/
+
+  prod:
+    mode: production
+    variables:
+      schema: sdp_evolution_prod

--- a/data-engineering/sdp-evolution/resources/pipeline.yml
+++ b/data-engineering/sdp-evolution/resources/pipeline.yml
@@ -1,0 +1,17 @@
+resources:
+  pipelines:
+    orders_pipeline:
+      name: sdp-evolution-${bundle.target}
+      serverless: true
+      catalog: ${var.catalog}
+      schema: ${resources.schemas.demo_schema.name}
+      channel: PREVIEW
+      configuration:
+        source.path: /Volumes/${var.catalog}/${resources.schemas.demo_schema.name}/${resources.volumes.landing.name}/orders
+        target.catalog: ${var.catalog}
+        target.schema: ${resources.schemas.demo_schema.name}
+      libraries:
+        - file:
+            path: ../src/pipeline.py
+        - file:
+            path: ../src/reconcile.py

--- a/data-engineering/sdp-evolution/resources/seed_jobs.yml
+++ b/data-engineering/sdp-evolution/resources/seed_jobs.yml
@@ -1,0 +1,45 @@
+resources:
+  jobs:
+    seed_v1_job:
+      name: sdp-evolution-seed-v1-${bundle.target}
+      description: "Step 1 - land the clean v1 baseline batch into the landing volume."
+      tasks:
+        - task_key: seed_v1
+          environment_key: default
+          spark_python_task:
+            python_file: ../src/seed_data.py
+            parameters:
+              - "--catalog"
+              - "${var.catalog}"
+              - "--schema"
+              - "${resources.schemas.demo_schema.name}"
+              - "--volume"
+              - "${resources.volumes.landing.name}"
+              - "--version"
+              - "v1"
+      environments:
+        - environment_key: default
+          spec:
+            client: "3"
+
+    seed_v2_job:
+      name: sdp-evolution-seed-v2-${bundle.target}
+      description: "Step 3 - land the drifted v2 batch (rename + type change + new column)."
+      tasks:
+        - task_key: seed_v2
+          environment_key: default
+          spark_python_task:
+            python_file: ../src/seed_data.py
+            parameters:
+              - "--catalog"
+              - "${var.catalog}"
+              - "--schema"
+              - "${resources.schemas.demo_schema.name}"
+              - "--volume"
+              - "${resources.volumes.landing.name}"
+              - "--version"
+              - "v2"
+      environments:
+        - environment_key: default
+          spec:
+            client: "3"

--- a/data-engineering/sdp-evolution/resources/test_job.yml
+++ b/data-engineering/sdp-evolution/resources/test_job.yml
@@ -1,0 +1,8 @@
+resources:
+  jobs:
+    test_job:
+      name: sdp-evolution-tests-${bundle.target}
+      tasks:
+        - task_key: unit_tests
+          notebook_task:
+            notebook_path: ../tests/test_reconcile_notebook.py

--- a/data-engineering/sdp-evolution/resources/uc.yml
+++ b/data-engineering/sdp-evolution/resources/uc.yml
@@ -1,0 +1,14 @@
+resources:
+  schemas:
+    demo_schema:
+      name: ${var.schema}
+      catalog_name: ${var.catalog}
+      comment: SDP schema evolution demo schema
+
+  volumes:
+    landing:
+      name: landing
+      catalog_name: ${var.catalog}
+      schema_name: ${resources.schemas.demo_schema.name}
+      volume_type: MANAGED
+      comment: Landing volume for orders JSON batches

--- a/data-engineering/sdp-evolution/src/generate_data.py
+++ b/data-engineering/sdp-evolution/src/generate_data.py
@@ -1,0 +1,60 @@
+"""Shared data generation helpers for the SDP schema-evolution demo.
+
+Pure stdlib so it imports and runs anywhere (plain python, notebooks, bundles).
+"""
+
+import json
+import os
+
+
+def v1_records() -> list[dict]:
+    """Clean v1 orders: amount is a stringified number, name is `cust_name`."""
+    return [
+        {"order_id": "o-001", "cust_name": "Alice", "amount": "125.50", "order_ts": "2026-07-01T09:15:00"},
+        {"order_id": "o-002", "cust_name": "Bob", "amount": "42.00", "order_ts": "2026-07-02T11:30:00"},
+        {"order_id": "o-003", "cust_name": "Carol", "amount": "310.75", "order_ts": "2026-07-03T14:05:00"},
+        {"order_id": "o-004", "cust_name": "Dan", "amount": "18.99", "order_ts": "2026-07-04T16:45:00"},
+        {"order_id": "o-005", "cust_name": "Eve", "amount": "205.20", "order_ts": "2026-07-05T08:00:00"},
+    ]
+
+
+def v2_records() -> list[dict]:
+    """Drifted v2 orders: `cust_name`->`customer_name`, amount float, + `loyalty_tier`."""
+    return [
+        {"order_id": "o-101", "customer_name": "Frank", "amount": 88.40, "loyalty_tier": "gold", "order_ts": "2026-07-14T09:00:00"},
+        {"order_id": "o-102", "customer_name": "Grace", "amount": 512.00, "loyalty_tier": "silver", "order_ts": "2026-07-14T12:20:00"},
+        {"order_id": "o-103", "customer_name": "Heidi", "amount": 27.35, "loyalty_tier": "bronze", "order_ts": "2026-07-15T10:10:00"},
+        {"order_id": "o-104", "customer_name": "Ivan", "amount": 149.99, "loyalty_tier": "gold", "order_ts": "2026-07-15T15:40:00"},
+        {"order_id": "o-105", "customer_name": "Judy", "amount": 63.10, "loyalty_tier": "bronze", "order_ts": "2026-07-16T08:55:00"},
+    ]
+
+
+def write_json(records: list[dict], dest_dir: str, filename: str) -> str:
+    """Write records as newline-delimited JSON to dest_dir/filename. Returns full path.
+
+    Uses plain file IO: on serverless a /Volumes path is a normal FUSE path.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    path = os.path.join(dest_dir, filename)
+    with open(path, "w") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+    return path
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        p1 = write_json(v1_records(), tmp, "orders_v1.json")
+        p2 = write_json(v2_records(), tmp, "orders_v2.json")
+
+        for path, expected in ((p1, v1_records()), (p2, v2_records())):
+            assert os.path.exists(path), f"missing file: {path}"
+            with open(path) as f:
+                lines = [ln for ln in f.read().splitlines() if ln.strip()]
+            assert len(lines) == len(expected), f"line count mismatch in {path}"
+            for ln in lines:
+                json.loads(ln)  # each line must be valid JSON
+
+    print("self-check OK: v1 and v2 files written, line counts and JSON valid")

--- a/data-engineering/sdp-evolution/src/pipeline.py
+++ b/data-engineering/sdp-evolution/src/pipeline.py
@@ -1,0 +1,59 @@
+# SDP (Spark Declarative Pipelines) - schema evolution demo.
+#
+# Bronze ingests JSON with Auto Loader in "rescue" schema-evolution mode: any
+# column that gets renamed, retyped, or newly added after v1 is captured in the
+# _rescued_data column instead of failing the stream. That means the pipeline
+# keeps running through drift, and all the drifted data is recoverable later.
+
+from pyspark import pipelines as dp
+from pyspark.sql import functions as F
+
+# Bundle deploys src/ onto the path, so this sibling import resolves.
+from reconcile import reconcile, RESCUE_SCHEMA  # noqa: F401
+
+source_path = spark.conf.get("source.path")
+
+BRONZE_SCHEMA = "order_id string, cust_name string, amount string, order_ts string"
+
+
+@dp.table(name="orders_bronze")
+def orders_bronze():
+    return (
+        spark.readStream.format("cloudFiles")
+        .option("cloudFiles.format", "json")
+        .option("cloudFiles.schemaEvolutionMode", "rescue")
+        .option("rescuedDataColumn", "_rescued_data")
+        .schema(BRONZE_SCHEMA)
+        .load(source_path)
+    )
+
+
+@dp.materialized_view(name="orders_silver")
+def orders_silver():
+    df = spark.read.table("orders_bronze")
+    # ==== STEP 4: SCHEMA EVOLUTION RECONCILIATION ====
+    # Two states of this view:
+    #
+    #   STATE 1 (shipped, active below): silver simply passes through the fixed
+    #   v1 business columns. After v2 drift, new rows show null customer_name /
+    #   amount because the upstream renamed/retyped fields were rescued into
+    #   _rescued_data rather than the base columns.
+    #
+    #   STATE 2 (the fix): wrap the STATE 1 passthrough return in triple quotes
+    #   and activate `return reconcile(df)`. reconcile() coalesces each business
+    #   column with the matching field pulled back out of _rescued_data, so both
+    #   old v1 rows and new v2 rows resolve correctly.
+    
+    # START OF STATE 1
+    return df.select(
+        "order_id",
+        F.col("cust_name").alias("customer_name"),
+        F.col("amount").cast("double").alias("amount"),
+        F.lit(None).cast("string").alias("loyalty_tier"),
+        "order_ts",
+    )
+    # END OF STATE 1
+
+    # START OF STATE 2
+    # return reconcile(df)
+    # END OF STATE 2

--- a/data-engineering/sdp-evolution/src/reconcile.py
+++ b/data-engineering/sdp-evolution/src/reconcile.py
@@ -1,0 +1,28 @@
+"""Schema-evolution reconciliation for the SDP orders silver table.
+
+Bronze ingests with Auto Loader in rescue mode, so any columns that get
+renamed, retyped, or newly added after v1 land in the `_rescued_data` column
+instead of breaking the pipeline. `reconcile` recovers those values back out of
+`_rescued_data` via `coalesce`: for each business column it prefers the base
+column and falls back to the rescued JSON. This keeps silver whole after drift
+WITHOUT a full refresh - old v1 rows and new v2 rows both resolve correctly.
+
+Null handling: `from_json` of a null `_rescued_data` yields a null struct, so
+every field access is null and `coalesce` falls back to the base column. That
+is exactly right for clean v1 rows that were never rescued.
+"""
+
+from pyspark.sql import functions as F, DataFrame
+
+RESCUE_SCHEMA = "customer_name string, amount double, loyalty_tier string"
+
+
+def reconcile(df: DataFrame) -> DataFrame:
+    r = F.from_json(F.col("_rescued_data"), RESCUE_SCHEMA)
+    return df.select(
+        "order_id",
+        F.coalesce(F.col("cust_name"), r["customer_name"]).alias("customer_name"),
+        F.coalesce(F.col("amount").cast("double"), r["amount"]).alias("amount"),
+        r["loyalty_tier"].alias("loyalty_tier"),
+        "order_ts",
+    )

--- a/data-engineering/sdp-evolution/src/seed_data.py
+++ b/data-engineering/sdp-evolution/src/seed_data.py
@@ -1,0 +1,39 @@
+"""Seed order data into the landing volume for the SDP schema-evolution demo.
+
+Runs as a serverless job task so end users trigger a job, never a notebook.
+
+  --version v1  lands the clean baseline batch (step 1).
+  --version v2  lands the drifted batch: rename + type change + new column (step 3).
+
+Schema and volume are created by the Databricks Asset Bundle on deploy.
+This job only writes JSON into the existing volume.
+
+Same-directory import of `generate_data` works because Python puts the running
+script's own directory on sys.path.
+"""
+
+import argparse
+
+from generate_data import v1_records, v2_records, write_json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--catalog", required=True)
+    parser.add_argument("--schema", required=True)
+    parser.add_argument("--volume", default="landing")
+    parser.add_argument("--version", required=True, choices=["v1", "v2"])
+    args = parser.parse_args()
+
+    landing_dir = f"/Volumes/{args.catalog}/{args.schema}/{args.volume}/orders"
+    if args.version == "v1":
+        records, filename = v1_records(), "orders_v1.json"
+    else:
+        records, filename = v2_records(), "orders_v2.json"
+
+    path = write_json(records, landing_dir, filename)
+    print(f"wrote {len(records)} {args.version} records to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data-engineering/sdp-evolution/tests/test_reconcile_notebook.py
+++ b/data-engineering/sdp-evolution/tests/test_reconcile_notebook.py
@@ -1,0 +1,48 @@
+# Databricks notebook source
+# Unit tests for reconcile(), as a single self-contained notebook.
+# Job success == all asserts pass. Any failure raises and fails the run.
+
+import os
+import sys
+
+# Add the bundle's src/ (sibling of tests/) to the path so we import the real code.
+nb_dir = os.path.dirname(
+    dbutils.notebook.entry_point.getDbutils().notebook().getContext().notebookPath().get()
+)
+sys.path.insert(0, "/Workspace" + os.path.join(os.path.dirname(nb_dir), "src"))
+
+from reconcile import reconcile
+
+INPUT_SCHEMA = (
+    "order_id string, cust_name string, amount string, "
+    "order_ts string, _rescued_data string"
+)
+
+# COMMAND ----------
+
+# v1 passthrough: clean row, no rescued data.
+df = spark.createDataFrame(
+    [("o1", "Alice", "10.5", "2026-01-01T00:00:00", None)],
+    schema=INPUT_SCHEMA,
+)
+row = reconcile(df).collect()[0]
+assert row["customer_name"] == "Alice", row["customer_name"]
+assert row["amount"] == 10.5, row["amount"]
+assert row["loyalty_tier"] is None, row["loyalty_tier"]
+
+# COMMAND ----------
+
+# v2 drift recovered: values pulled back out of _rescued_data.
+rescued = '{"customer_name":"Frank","amount":210.0,"loyalty_tier":"gold"}'
+df = spark.createDataFrame(
+    [("o2", None, None, "2026-02-02T00:00:00", rescued)],
+    schema=INPUT_SCHEMA,
+)
+row = reconcile(df).collect()[0]
+assert row["customer_name"] == "Frank", row["customer_name"]
+assert row["amount"] == 210.0, row["amount"]
+assert row["loyalty_tier"] == "gold", row["loyalty_tier"]
+
+# COMMAND ----------
+
+print("All reconcile tests passed.")


### PR DESCRIPTION
# Pull Request

## Description
Adds a new agent-runnable Databricks Asset Bundle demo under `data-engineering/sdp-evolution` that shows how to handle schema evolution (column renames, type changes, new columns) in Spark Declarative Pipelines using Auto Loader rescue mode and silver reconciliation from `_rescued_data`, without a full refresh.

Also updates `data-engineering/README.md` to index the project.

## Category
- [ ] core-platform
- [x] data-engineering
- [ ] data-governance
- [ ] data-warehousing
- [ ] genai-ml
- [ ] launch-accelerator
- [ ] workspace-setup

## Type of Change
- [x] New project
- [ ] Bug fix
- [ ] Enhancement
- [ ] Documentation

## Project Details
**Project Name:** SDP Schema Evolution (Rescued Data Column)
**Purpose:** Teach the fixed-bronze + rescue + silver-reconcile pattern for SDP schema drift without full refresh; README is an AI-harness runbook with verification pauses.
**Technologies Used:** Databricks Asset Bundles, Spark Declarative Pipelines, Auto Loader, Unity Catalog schemas/volumes, serverless jobs

## Testing
- [x] Code runs without errors
- [x] Documentation is complete
- [x] Used only synthetic data

## Security Compliance ✅
- [x] No customer data, PII, or proprietary information
- [x] No credentials or access tokens
- [x] Only synthetic data used
- [x] Third-party licenses acknowledged

---

**By submitting this PR, I confirm I have followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and security requirements.**