### PR TITLE
Add AIM User-Ownership Inventory notebook (workspace-setup)

### DIFF
--- a/workspace-setup/README.md
+++ b/workspace-setup/README.md
@@ -1,1 +1,7 @@
 # Workspace Setup
+
+## Projects
+
+### [AIM User-Ownership Inventory](./aim-user-ownership-inventory/)
+
+A report-only Databricks notebook that inventories every workspace object owned or controlled by a given set of users, so nothing is lost when those users are deleted. Designed as a follow-on to the Automatic Identity Management (AIM) migration prep script: run it on the users prep flags as divergent/failing (commonly former employees) before removing any accounts, to confirm what they still own and transfer anything that must survive.

--- a/workspace-setup/aim-user-ownership-inventory/README.md
+++ b/workspace-setup/aim-user-ownership-inventory/README.md
@@ -1,0 +1,140 @@
+# AIM User-Ownership Inventory
+
+A **report-only** Databricks notebook that inventories every workspace object owned or
+controlled by a given set of users, so that **nothing is lost when those users are
+deleted**. It is designed as a follow-on to the Automatic Identity Management (AIM)
+migration prep script: run it on the users that prep flags as divergent/failing before
+you remove any accounts.
+
+## Project Support
+
+Please note that this project is provided for your exploration only and is not formally
+supported by Databricks with Service Level Agreements (SLAs). It is provided AS-IS, and we
+do not make any guarantees. Please do not submit a support ticket relating to any issues
+arising from the use of this project.
+
+## Background: why this exists
+
+When you enable [Automatic Identity Management (AIM)](https://docs.databricks.com/aws/en/admin/users-groups/automatic-identity-management/),
+Databricks matches each identity to Microsoft Entra ID using the Entra **Object ID**. The
+[migration prep script](https://docs.databricks.com/aws/en/admin/users-groups/automatic-identity-management/migrate-to-aim#prepare-for-migration)
+produces a set of result files, including `idp_divergence_users.csv`, listing users whose
+Databricks identity diverges from Entra or cannot be matched.
+
+A very common outcome is that many of the divergent/failing users are **former employees**
+whose accounts should be deleted. Before deleting them, admins need to answer a practical
+question:
+
+> *Do any of these users own assets that are still in use, and would we lose anything by
+> deleting the account?*
+
+Deleting a user in Databricks removes their home folder (`/Users/<email>/`) and everything
+in it, and can break jobs, dashboards, and alerts that depend on that user. This notebook
+gives you a clear, per-user inventory so you can **transfer anything that must survive
+before you delete the account**.
+
+## When to use this
+
+- **After running the AIM migration prep script**, when you have `idp_divergence_users.csv`
+  (or any list of users) and need to clean up former-employee accounts.
+- More generally, **any time you offboard users** and want to confirm what they own before
+  deletion.
+
+You do **not** need AIM to be enabled to run this. It only reads the current workspace.
+
+## What it reports (per user)
+
+- **Home-folder contents** — notebooks, files, and folders under `/Users/<email>/`. **This
+  is the most important category**, because a user's home folder is deleted along with the
+  account. Anything here that must survive has to be moved or transferred first.
+- **Jobs** — `creator_user_name` and `run_as`. A job whose `run_as` points at a deleted
+  user will stop running.
+- **DBSQL queries and alerts** — owner.
+- **Lakeview (AI/BI) dashboards** — `CAN_MANAGE` holder (see note on ownership below).
+- **DLT / Lakeflow pipelines** — creator.
+- **Clusters and cluster policies** — creator / single-user.
+- **SQL warehouses** — creator.
+- **Registered models and MLflow experiments** — owner / `CAN_MANAGE`.
+- **Repos** — path under `/Repos/<user>/`.
+- **Personal access tokens** — `created_by_username` (the token becomes invalid on
+  deletion).
+
+Output is a single table and a CSV, one row per owned object.
+
+## Important scope and design notes
+
+- **This notebook is workspace-scoped.** It inventories objects in the single workspace
+  where you run it. Under identity federation, user *identities* are shared across your
+  account, but the *objects* (home folders, jobs, queries, dashboards, and so on) live in a
+  specific workspace. **If more than one workspace is in scope, run the notebook once in
+  each workspace** with the same user list. The output includes `workspace_id` and
+  `workspace_host` columns so results from multiple workspaces combine cleanly.
+- **It is report-only.** It never transfers, deletes, or modifies anything. Transferring
+  ownership is a deliberate, manual step you take after reviewing the output.
+- **It does not cover Unity Catalog objects** (catalogs, schemas, tables, volumes, UC
+  models). Those are governed at the **metastore** level, not per workspace, and require a
+  metastore admin to review and transfer (`ALTER <object> OWNER TO ...`). Run a separate UC
+  ownership check for those.
+- **On the word "ownership":** workspace objects such as notebooks, files, dashboards, and
+  experiments do **not** expose an `IS_OWNER` ACL level — their ACLs top out at
+  `CAN_MANAGE`. Notebook/file "ownership" is therefore determined by the **home-folder
+  path**, and for dashboards/experiments the notebook reports `CAN_MANAGE` holders as the
+  closest available control signal.
+
+## Prerequisites
+
+- You must be a **workspace administrator** in the workspace you are scanning (needed to
+  list objects and read their permissions across the workspace).
+- Compute to run the notebook — **Serverless** is sufficient; no special configuration is
+  required. All operations use the Databricks REST APIs via the
+  [Databricks SDK for Python](https://databricks-sdk-py.readthedocs.io/), which is
+  preinstalled on Databricks Runtime.
+
+## How to use
+
+1. **Import the notebook** into your workspace: `Workspace > Import > File` and select
+   `user_owned_objects_inventory.py`.
+2. **Provide the users** in the first (Configuration) cell, using either:
+   - `USER_IDS` — a list of Databricks numeric user IDs (the `id` column from the prep
+     script's `idp_divergence_users.csv`) and/or emails, or
+   - `FAILURES_CSV_PATH` — a path to the uploaded `idp_divergence_users.csv` (a UC Volume
+     or workspace path); the notebook reads the `id` column for you.
+3. Optionally set `OUTPUT_VOLUME_PATH` to a UC Volume so the CSV persists and is shareable.
+4. **Run all.** Review the summary, the interactive table, and the exported CSV.
+
+### Example configuration
+
+```python
+# Option A: paste IDs from the prep script's idp_divergence_users.csv "id" column
+USER_IDS = ["8714258940588932", "70507760680636"]
+
+# Option B: let the notebook read the ids from the CSV directly
+FAILURES_CSV_PATH = "/Volumes/main/default/aim_offboarding/idp_divergence_users.csv"
+```
+
+The notebook resolves each ID to its email via SCIM, then scans. Any input that cannot be
+resolved (for example, an already-deleted account) is listed separately rather than
+silently dropped.
+
+## Recommended offboarding workflow
+
+1. **Inventory** the departing users with this notebook (once per in-scope workspace).
+2. **Review** the output. For each object, decide: transfer, or safe to drop.
+3. **Transfer ownership** of anything that must survive, *before* deleting the user:
+   - Most objects: Permissions API —
+     `PUT /api/2.0/permissions/{type}/{id}` with an access control list granting the new
+     owner `IS_OWNER` (or `CAN_MANAGE` where `IS_OWNER` is not supported).
+   - Dashboards: also assignable via the dashboard **Share** UI (workspace admin).
+   - Jobs whose `run_as` is the departing user: repoint `run_as` to a service principal or
+     active owner, or the job will stop running.
+4. **Unity Catalog** (separate check): as a metastore admin, review and transfer UC objects
+   with `ALTER <CATALOG|SCHEMA|TABLE|...> OWNER TO ...`.
+5. **Re-run** this notebook to confirm the user owns nothing, then delete the account.
+
+## Security and data
+
+- The notebook reads only metadata (object names, IDs, paths, owner/creator fields, ACLs).
+  It reads no data inside tables or files.
+- It writes no credentials and requires none beyond the running admin's own workspace
+  authentication.
+- It performs no mutating operations.

--- a/workspace-setup/aim-user-ownership-inventory/user_owned_objects_inventory.py
+++ b/workspace-setup/aim-user-ownership-inventory/user_owned_objects_inventory.py
@@ -1,0 +1,519 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # User-Owned Workspace Objects Inventory (Report-Only)
+# MAGIC
+# MAGIC **Purpose:** Before deleting users who have left the company, find every workspace
+# MAGIC object each of them **owns or controls**, so nothing is orphaned or lost. This notebook
+# MAGIC is **read-only** — it never changes, deletes, or reassigns anything. It only reports.
+# MAGIC
+# MAGIC **Who runs it:** A **workspace admin** (needs permission to list objects and read their
+# MAGIC permissions). Run it once per workspace you want to check.
+# MAGIC
+# MAGIC **What it finds, per user:**
+# MAGIC - **Home-folder contents (notebooks / files / folders)** — everything under
+# MAGIC   `/Users/<email>/`. **This is the most important category: this content is deleted
+# MAGIC   along with the user account**, so anything here that must survive has to be moved out
+# MAGIC   or transferred first.
+# MAGIC - **Jobs** — `creator_user_name` and `run_as` (a job whose `run_as` points at a deleted user will stop running)
+# MAGIC - **DBSQL queries & alerts** — owner
+# MAGIC - **Lakeview (AI/BI) dashboards** — `CAN_MANAGE` on the ACL (see note below)
+# MAGIC - **DLT / Lakeflow pipelines** — `creator_user_name`
+# MAGIC - **Clusters & cluster policies** — creator / single-user
+# MAGIC - **SQL warehouses** — creator
+# MAGIC - **Registered models & MLflow experiments** — owner / `CAN_MANAGE`
+# MAGIC - **Repos** — path under `/Repos/<user>/`
+# MAGIC - **Personal access tokens** — `created_by_username`
+# MAGIC
+# MAGIC **Note on "ownership" signal:** Workspace objects (notebooks, files, dashboards,
+# MAGIC experiments) do **not** expose an `IS_OWNER` ACL level — their ACLs only go up to
+# MAGIC `CAN_MANAGE`. Notebook/file ownership is instead defined by the **home-folder path**.
+# MAGIC For dashboards/experiments this notebook reports `CAN_MANAGE` holders as the closest
+# MAGIC available control signal, so review those rows as "manages" rather than strict "owns".
+# MAGIC
+# MAGIC **What it does NOT cover:** Unity Catalog objects (catalogs, schemas, tables, UC models,
+# MAGIC volumes). Those are **metastore-scoped**, not workspace-scoped, and their ownership is
+# MAGIC managed separately (metastore admin, `SHOW GRANTS` / `ALTER ... OWNER TO`). Run a
+# MAGIC separate UC check for those.
+# MAGIC
+# MAGIC **How to use:** Provide the departing users by their **Databricks numeric user ID**
+# MAGIC (the `id` column from the prep script's `idp_divergence_users.csv`) in `USER_IDS`, or
+# MAGIC point `FAILURES_CSV_PATH` at the uploaded CSV to load them automatically. Emails work
+# MAGIC too. The notebook resolves each ID to its email via SCIM, then **Run all**. Review the
+# MAGIC final table / exported CSV. For anything that must survive the user's deletion,
+# MAGIC transfer ownership (Permissions API, or the object's UI) **before** deleting the account.
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 1. Configuration
+
+# COMMAND ----------
+
+# Users to inventory (the departing / ex-employee accounts). You can identify them by
+# either their Databricks numeric user ID or their email — mix freely.
+#
+# The prep script's idp_divergence_users.csv emits the numeric "id" column; paste those
+# here directly (as strings or ints). Emails also work if you have them.
+#   USER_IDS = ["8714258940588932", "70507760680636"]        # from the CSV "id" column
+#   USER_IDS = ["user1@example.com"]                        # emails are fine too
+USER_IDS = [
+    "8714258940588932",
+]
+
+# Convenience: load IDs straight from the prep script's CSV instead of pasting them.
+# Point this at the uploaded idp_divergence_users.csv (UC Volume or workspace path).
+# When set, its "id" column is used and USER_IDS above is ignored.
+FAILURES_CSV_PATH = None  # e.g. "/Volumes/main/default/aim_offboarding/idp_divergence_users.csv"
+
+# Inventory each user's home folder (/Users/<email>/). This is the critical category:
+# home-folder contents are DELETED with the user account. Strongly recommended to keep True.
+SCAN_HOME_FOLDER = True
+
+# For ACL-based objects (dashboards, experiments), workspace ACLs top out at CAN_MANAGE —
+# there is no IS_OWNER level for these. We therefore report CAN_MANAGE holders as the
+# closest control signal. Set False to skip these (fewer, noisier rows).
+INCLUDE_CAN_MANAGE = True
+
+# Where to write the CSV. A UC Volume path is recommended so it persists and is shareable.
+# Leave as None to write to the driver's local /tmp and display inline only.
+OUTPUT_VOLUME_PATH = None  # e.g. "/Volumes/main/default/aim_offboarding"
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 2. Setup
+
+# COMMAND ----------
+
+from databricks.sdk import WorkspaceClient
+import pandas as pd
+from datetime import datetime, timezone
+
+w = WorkspaceClient()
+HOST = w.config.host.rstrip("/") if w.config.host else ""
+
+# Identify THIS workspace so results are unambiguous when you run the notebook in several
+# workspaces and concatenate the CSVs. (Identities are shared account-wide under federation,
+# but the objects below are per-workspace — this column records which workspace each came from.)
+try:
+    WORKSPACE_ID = str(w.get_workspace_id())
+except Exception:
+    WORKSPACE_ID = ""
+WORKSPACE_HOST = HOST
+print(f"Workspace: {WORKSPACE_HOST} (id={WORKSPACE_ID})")
+
+# --- Build the raw input list (from CSV if provided, else from USER_IDS) ---
+raw_inputs = []
+if FAILURES_CSV_PATH:
+    # Read the prep script's CSV and pull its "id" column.
+    read_path = FAILURES_CSV_PATH
+    if read_path.startswith("/Volumes") or read_path.startswith("/Workspace"):
+        # pandas can read UC Volume / workspace files directly on serverless & clusters.
+        pass
+    _csv = pd.read_csv(read_path, dtype=str)
+    id_col = next((c for c in _csv.columns if c.strip().lower() == "id"), None)
+    if id_col is None:
+        raise ValueError(f"No 'id' column found in {read_path}. Columns: {list(_csv.columns)}")
+    raw_inputs = [v for v in _csv[id_col].dropna().tolist() if str(v).strip()]
+    print(f"Loaded {len(raw_inputs)} id(s) from {read_path}")
+else:
+    raw_inputs = [str(x).strip() for x in USER_IDS if str(x).strip()]
+
+# --- Resolve each input (numeric ID or email) to a canonical email via SCIM ---
+# Object owner/creator fields and home-folder paths key off the email (userName), so we
+# resolve everything to email up front. Numeric IDs are looked up directly; emails are
+# validated (and normalized) via a filter query.
+def _resolve_to_email(token):
+    t = str(token).strip()
+    try:
+        if t.isdigit():
+            u = w.users.get(id=t)
+            return (u.user_name, None)
+        else:
+            # treat as email/userName — validate it exists
+            matches = list(w.users.list(filter=f'userName eq "{t}"', count=1))
+            if matches:
+                return (matches[0].user_name, None)
+            return (t.lower(), "not found in directory (may already be deleted)")
+    except Exception as e:
+        return (None, f"{type(e).__name__}: {e}")
+
+TARGETS = set()          # canonical lowercased emails to match against
+RESOLVED = []            # (input_token, email, note) for the report
+UNRESOLVED = []          # inputs we could not map to an email
+for token in raw_inputs:
+    email, note = _resolve_to_email(token)
+    if email:
+        TARGETS.add(email.strip().lower())
+        RESOLVED.append((token, email, note or ""))
+    else:
+        UNRESOLVED.append((token, note))
+
+print(f"Inventorying {len(TARGETS)} user(s):")
+for tok, email, note in sorted(RESOLVED, key=lambda r: r[1]):
+    suffix = f"  <-- {note}" if note else ""
+    print(f"  - {tok} => {email}{suffix}")
+if UNRESOLVED:
+    print(f"\n{len(UNRESOLVED)} input(s) could NOT be resolved to an email (skipped):")
+    for tok, note in UNRESOLVED:
+        print(f"  - {tok}: {note}")
+    print("  A deleted account has no home folder to scan, but it may still own objects "
+          "(creator fields persist). Consider checking these IDs before this run if possible.")
+
+findings = []  # each: dict(user_email, object_type, ownership_signal, object_id, object_name, object_path, url, notes)
+
+
+def add(user_email, object_type, signal, object_id="", name="", path="", url="", notes=""):
+    findings.append({
+        "workspace_id": WORKSPACE_ID,
+        "workspace_host": WORKSPACE_HOST,
+        "user_email": user_email,
+        "object_type": object_type,
+        "ownership_signal": signal,
+        "object_id": str(object_id),
+        "object_name": name or "",
+        "object_path": path or "",
+        "url": url,
+        "notes": notes,
+    })
+
+
+def match(value):
+    """Return the target email (lowercased) if value matches one of our targets, else None."""
+    if not value:
+        return None
+    v = str(value).strip().lower()
+    return v if v in TARGETS else None
+
+
+def owner_from_acl(object_type_api, object_id):
+    """Return list of (target_email, permission_level) for target users holding IS_OWNER,
+    or CAN_MANAGE when INCLUDE_CAN_MANAGE is set, on the given object.
+
+    Note: workspace objects (notebooks, files, dashboards, experiments) do NOT expose an
+    IS_OWNER level — their ACLs top out at CAN_MANAGE. So for those, CAN_MANAGE is the
+    strongest available control signal. Home-folder ownership is handled separately by path."""
+    hits = []
+    try:
+        perms = w.permissions.get(request_object_type=object_type_api, request_object_id=str(object_id))
+    except Exception:
+        return hits
+    for acl in (perms.access_control_list or []):
+        tgt = match(getattr(acl, "user_name", None))
+        if not tgt:
+            continue
+        for p in (acl.all_permissions or []):
+            lvl = getattr(p.permission_level, "value", str(p.permission_level))
+            # Skip permissions inherited from a parent/group — only direct grants indicate control.
+            if getattr(p, "inherited", False):
+                continue
+            if lvl == "IS_OWNER" or (INCLUDE_CAN_MANAGE and lvl == "CAN_MANAGE"):
+                hits.append((tgt, lvl))
+    return hits
+
+
+def safe(section):
+    """Decorator: wrap a scan section so that calling it runs with error handling —
+    one failing API won't abort the whole inventory. Returns a callable (does NOT run
+    the scan at decoration time)."""
+    def deco(fn):
+        def wrapped():
+            try:
+                fn()
+                print(f"  [ok] {section}")
+            except Exception as e:
+                print(f"  [skip] {section}: {type(e).__name__}: {e}")
+        return wrapped
+    return deco
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 3. Scan compute, jobs, and SQL objects (fast — ownership/creator fields)
+
+# COMMAND ----------
+
+print("Scanning...")
+
+@safe("Jobs (creator + run_as)")
+def _jobs():
+    for j in w.jobs.list(expand_tasks=False):
+        jid = j.job_id
+        s = j.settings
+        name = getattr(s, "name", "") if s else ""
+        url = f"{HOST}/jobs/{jid}"
+        # creator
+        tgt = match(getattr(j, "creator_user_name", None))
+        if tgt:
+            add(tgt, "job", "creator_user_name", jid, name, url=url)
+        # run_as (critical: a job run_as a deleted user will fail)
+        run_as = getattr(s, "run_as", None) if s else None
+        run_as_user = getattr(run_as, "user_name", None) if run_as else None
+        tgt2 = match(run_as_user)
+        if tgt2:
+            add(tgt2, "job", "run_as (job will fail if user deleted)", jid, name, url=url,
+                notes="run_as points at this user")
+
+
+@safe("Clusters (creator + single-user)")
+def _clusters():
+    for c in w.clusters.list():
+        cid = c.cluster_id
+        name = getattr(c, "cluster_name", "")
+        url = f"{HOST}/#setting/clusters/{cid}"
+        tgt = match(getattr(c, "creator_user_name", None))
+        if tgt:
+            add(tgt, "cluster", "creator_user_name", cid, name, url=url)
+        tgt2 = match(getattr(c, "single_user_name", None))
+        if tgt2:
+            add(tgt2, "cluster", "single_user_name", cid, name, url=url,
+                notes="single-user (dedicated) cluster")
+
+
+@safe("Cluster policies (creator)")
+def _policies():
+    for p in w.cluster_policies.list():
+        tgt = match(getattr(p, "creator_user_name", None))
+        if tgt:
+            add(tgt, "cluster_policy", "creator_user_name",
+                getattr(p, "policy_id", ""), getattr(p, "name", ""))
+
+
+@safe("SQL warehouses (creator)")
+def _warehouses():
+    for wh in w.warehouses.list():
+        tgt = match(getattr(wh, "creator_name", None))
+        if tgt:
+            add(tgt, "sql_warehouse", "creator_name", getattr(wh, "id", ""),
+                getattr(wh, "name", ""), url=f"{HOST}/sql/warehouses/{getattr(wh,'id','')}")
+
+
+@safe("DLT / Lakeflow pipelines (creator)")
+def _pipelines():
+    for p in w.pipelines.list_pipelines():
+        tgt = match(getattr(p, "creator_user_name", None))
+        if tgt:
+            add(tgt, "pipeline", "creator_user_name", getattr(p, "pipeline_id", ""),
+                getattr(p, "name", ""),
+                url=f"{HOST}/pipelines/{getattr(p,'pipeline_id','')}")
+
+
+@safe("DBSQL queries (owner)")
+def _queries():
+    for q in w.queries.list():
+        owner = getattr(q, "owner_user_name", None)
+        tgt = match(owner)
+        if tgt:
+            add(tgt, "dbsql_query", "owner_user_name", getattr(q, "id", ""),
+                getattr(q, "display_name", "") or getattr(q, "name", ""))
+
+
+@safe("DBSQL alerts (owner)")
+def _alerts():
+    for a in w.alerts.list():
+        tgt = match(getattr(a, "owner_user_name", None))
+        if tgt:
+            add(tgt, "dbsql_alert", "owner_user_name", getattr(a, "id", ""),
+                getattr(a, "display_name", ""))
+
+
+@safe("Personal access tokens (created_by)")
+def _tokens():
+    for t in w.token_management.list():
+        tgt = match(getattr(t, "created_by_username", None))
+        if tgt:
+            add(tgt, "pat_token", "created_by_username", getattr(t, "token_id", ""),
+                getattr(t, "comment", "") or "(no comment)",
+                notes="token becomes invalid when user is deleted")
+
+_jobs(); _clusters(); _policies(); _warehouses(); _pipelines(); _queries(); _alerts(); _tokens()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 4. Scan Lakeview dashboards, models, experiments, repos
+
+# COMMAND ----------
+
+@safe("Lakeview (AI/BI) dashboards (IS_OWNER)")
+def _dashboards():
+    for d in w.lakeview.list():
+        did = getattr(d, "dashboard_id", "")
+        name = getattr(d, "display_name", "")
+        url = f"{HOST}/dashboardsv3/{did}"
+        for tgt, lvl in owner_from_acl("dashboards", did):
+            add(tgt, "lakeview_dashboard", f"ACL {lvl}", did, name, url=url)
+
+
+@safe("Unity Catalog registered models (owner)")
+def _uc_models():
+    # UC models carry an explicit owner. (Metastore-scoped, but listed here for convenience.)
+    for m in w.registered_models.list():
+        tgt = match(getattr(m, "owner", None))
+        if tgt:
+            add(tgt, "uc_registered_model", "owner", getattr(m, "full_name", ""),
+                getattr(m, "name", ""),
+                notes="Unity Catalog object — transfer via ALTER ... OWNER TO (metastore)")
+
+
+@safe("Legacy MLflow registered models (IS_OWNER)")
+def _legacy_models():
+    # Workspace model registry models use the Permissions API (registered-models).
+    for m in w.model_registry.list_models():
+        name = getattr(m, "name", "")
+        # permission id for registered-models is the model's id; resolve via get.
+        try:
+            got = w.model_registry.get_model(name=name)
+            mid = getattr(getattr(got, "registered_model_databricks", None), "id", None)
+        except Exception:
+            mid = None
+        if not mid:
+            continue
+        for tgt, lvl in owner_from_acl("registered-models", mid):
+            add(tgt, "mlflow_model", f"ACL {lvl}", mid, name)
+
+
+@safe("MLflow experiments (IS_OWNER)")
+def _experiments():
+    for ex in w.experiments.list_experiments():
+        eid = getattr(ex, "experiment_id", "")
+        name = getattr(ex, "name", "")
+        for tgt, lvl in owner_from_acl("experiments", eid):
+            add(tgt, "mlflow_experiment", f"ACL {lvl}", eid, name)
+
+
+@safe("Repos (path under /Repos/<user>)")
+def _repos():
+    for r in w.repos.list():
+        path = getattr(r, "path", "") or ""
+        # /Repos/<email>/<repo>
+        parts = path.split("/")
+        owner = parts[2] if len(parts) > 2 and parts[1] == "Repos" else None
+        tgt = match(owner)
+        if tgt:
+            add(tgt, "repo", "path /Repos/<user>", getattr(r, "id", ""),
+                getattr(r, "url", ""), path=path)
+
+_dashboards(); _uc_models(); _legacy_models(); _experiments(); _repos()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 5. Home-folder inventory — notebooks, files, folders under `/Users/<email>/`
+# MAGIC
+# MAGIC **This is the highest-priority category.** A user's home folder and everything in it
+# MAGIC is **deleted when the account is deleted**. Ownership here is defined by the *path*
+# MAGIC (`/Users/<email>/...`), not by an ACL — workspace objects have no `IS_OWNER` level.
+# MAGIC So we enumerate the tree directly. Controlled by `SCAN_HOME_FOLDER`.
+
+# COMMAND ----------
+
+if SCAN_HOME_FOLDER:
+    from databricks.sdk.service.workspace import ObjectType
+
+    def walk_home(user_email, path, counter):
+        try:
+            children = list(w.workspace.list(path))
+        except Exception as e:
+            print(f"  [skip dir] {path}: {e}")
+            return
+        for obj in children:
+            ot = obj.object_type
+            opath = getattr(obj, "path", "")
+            oid = getattr(obj, "object_id", "")
+            if ot in (ObjectType.NOTEBOOK, ObjectType.FILE, ObjectType.DIRECTORY):
+                counter[0] += 1
+                add(user_email, ot.value.lower(), "in home folder (deleted with user)",
+                    oid, opath.split("/")[-1], path=opath, url=f"{HOST}/#workspace{opath}",
+                    notes="lost on user deletion unless moved/exported")
+            if ot == ObjectType.DIRECTORY:
+                walk_home(user_email, opath, counter)
+
+    for email in sorted(TARGETS):
+        home = f"/Users/{email}"
+        # Confirm the home folder exists before walking.
+        try:
+            w.workspace.get_status(home)
+        except Exception:
+            print(f"  [no home folder] {home}")
+            continue
+        counter = [0]
+        walk_home(email, home, counter)
+        print(f"  {email}: {counter[0]} object(s) under {home}")
+else:
+    print("SCAN_HOME_FOLDER = False — skipping home-folder inventory (NOT recommended).")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 6. Results
+
+# COMMAND ----------
+
+df = pd.DataFrame(findings, columns=[
+    "workspace_id", "workspace_host", "user_email", "object_type", "ownership_signal",
+    "object_id", "object_name", "object_path", "url", "notes",
+])
+
+scan_ts = datetime.now(timezone.utc).isoformat()
+
+print(f"Scan timestamp (UTC): {scan_ts}")
+print(f"Total owned objects found: {len(df)}\n")
+
+if not df.empty:
+    print("Per-user summary:")
+    print(df.groupby("user_email").size().sort_values(ascending=False).to_string())
+    print("\nBy object type:")
+    print(df.groupby("object_type").size().sort_values(ascending=False).to_string())
+
+    # Users from the target list that own NOTHING found — safe to delete (workspace-side).
+    owned_users = set(df["user_email"].unique())
+    clean = sorted(TARGETS - owned_users)
+    print(f"\nUsers with NO workspace objects found ({len(clean)}) — "
+          f"workspace-side safe to delete (still verify Unity Catalog separately):")
+    for u in clean:
+        print(f"  - {u}")
+else:
+    print("No owned objects found for any listed user (workspace-side). "
+          "Still verify Unity Catalog ownership separately.")
+
+# COMMAND ----------
+
+# Display the full inventory as an interactive, sortable/filterable table.
+display(spark.createDataFrame(df) if not df.empty else spark.createDataFrame([], "user_email string"))
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 7. Export CSV
+
+# COMMAND ----------
+
+local_csv = "/tmp/user_owned_objects_inventory.csv"
+df.to_csv(local_csv, index=False)
+print(f"Wrote: {local_csv}")
+
+if OUTPUT_VOLUME_PATH:
+    import os
+    os.makedirs(OUTPUT_VOLUME_PATH, exist_ok=True)
+    vol_csv = f"{OUTPUT_VOLUME_PATH.rstrip('/')}/user_owned_objects_inventory.csv"
+    dbutils.fs.cp(f"file:{local_csv}", vol_csv)
+    print(f"Copied to volume: {vol_csv}")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## 8. Next steps (manual, deliberate)
+# MAGIC
+# MAGIC 1. **Review** the table above. For each row, decide: transfer, or safe to drop.
+# MAGIC 2. **Transfer ownership** of anything that must survive, *before* deleting the user:
+# MAGIC    - Most objects: Permissions API — `PUT /api/2.0/permissions/{type}/{id}` with
+# MAGIC      `{"access_control_list":[{"user_name":"new.owner@example.com","permission_level":"IS_OWNER"}]}`
+# MAGIC    - Dashboards: also assignable via the dashboard **Share** UI (workspace admin).
+# MAGIC    - Jobs with `run_as` on the departing user: update `run_as` to a service principal
+# MAGIC      or active owner, or the job **will stop running** on deletion.
+# MAGIC 3. **Unity Catalog** (separate check): as a metastore admin, review UC objects owned by
+# MAGIC    the user and use `ALTER <CATALOG|SCHEMA|TABLE|...> OWNER TO ...`.
+# MAGIC 4. **Re-run this notebook** to confirm the user owns nothing, then delete the account.
+# MAGIC
+# MAGIC > This notebook is intentionally **report-only**. It performs no transfers or deletions.


### PR DESCRIPTION
## Description

Adds a **report-only** Databricks notebook that inventories every workspace object owned or controlled by a given set of users, so that nothing is lost when those users are deleted. It is designed as a follow-on to the Automatic Identity Management (AIM) migration prep script: a common outcome of the prep script is a set of divergent/failing users who turn out to be former employees, and admins need to confirm what those users still own before removing the accounts. This notebook produces that per-user inventory.

## Category
- [ ] core-platform
- [ ] data-engineering
- [ ] data-governance
- [ ] data-warehousing
- [ ] genai-ml
- [ ] launch-accelerator
- [x] workspace-setup

## Type of Change
- [x] New project
- [ ] Bug fix
- [ ] Enhancement
- [x] Documentation

## Project Details
**Project Name:** AIM User-Ownership Inventory
**Purpose:** Before deleting users (typically former employees flagged by the AIM migration prep script), inventory every workspace object they own or control so anything still in use can be transferred first. Report-only; performs no transfers or deletions.
**Technologies Used:** Python, Databricks SDK for Python, Databricks REST APIs (Workspace, Jobs, Permissions, SCIM), pandas

## Key details
- Accepts numeric user IDs straight from the prep script's `idp_divergence_users.csv` (`id` column), the CSV path directly, and/or emails; resolves each to an email via SCIM before scanning.
- Inventories home-folder contents (notebooks/files/folders under `/Users/<user>/`), jobs (including `run_as`), DBSQL queries/alerts, dashboards, pipelines, clusters/policies, SQL warehouses, MLflow models/experiments, repos, and personal access tokens.
- Output is a single table and CSV, one row per owned object, with `workspace_id`/`workspace_host` columns.
- **Workspace-scoped by design:** identities are shared account-wide under federation, but objects live in a specific workspace, so it is run once per in-scope workspace and the workspace columns let results combine cleanly.
- **Report-only:** it never transfers, deletes, or modifies anything. Unity Catalog objects are explicitly called out as a separate metastore-admin check.

## Testing
- [x] Code runs without errors
- [x] Documentation is complete
- [x] Used only synthetic data

Tested end to end on a Databricks workspace (serverless), including the ID-based input path and multi-workspace `workspace_id` column. No customer or production data is included.

## Security Compliance ✅
- [x] No customer data, PII, or proprietary information
- [x] No credentials or access tokens
- [x] Only synthetic data used
- [x] Third-party licenses acknowledged

---

**By submitting this PR, I confirm I have followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines and security requirements.**

This pull request and its description were written by Isaac.
