### PR TITLE
Add Customer 360 Lakehouse: end-to-end Genie + DABs example (core-pla…

### DIFF
--- a/core-platform/cicd/customer-360-lakehouse-genie/.github/workflows/deploy.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/.github/workflows/deploy.yml
@@ -1,0 +1,95 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# GitHub Actions CI/CD for the Customer 360 Lakehouse bundle.
+#
+# STRATEGY (same across all four CI platforms in this repo) — the full lifecycle:
+#   1. Push to a feature branch  → validate + DEPLOY to the DEV workspace.
+#   2. Pull request → main       → VALIDATE only (cheap, no-compute merge gate).
+#   3. Merge/push to main        → DEPLOY to PROD as a SERVICE PRINCIPAL.
+#
+# Each deploy is a 3-PHASE flow: deploy all-except-Genie → run the setup job to
+# build the tables → full deploy (adds Genie). This is required because the
+# genie_spaces resource validates its bound tables exist at deploy time, but the
+# setup job builds those tables at run time. See AGENTS.md / README.
+#
+# AUTH: OAuth machine-to-machine (M2M). The CLI reads three env vars:
+#   DATABRICKS_HOST, DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET
+# Store the *_CLIENT_ID / *_CLIENT_SECRET as GitHub repo secrets (Settings →
+# Secrets and variables → Actions). Use one service principal per environment.
+#
+# NOTE: adjust the feature-branch glob ('feature/**') to your team's convention.
+# ⚠️ Public-repo note: deploying on branches/PRs from FORKS would expose secrets
+#   to untrusted code. This example assumes same-repo branches; harden before
+#   enabling on a public repo.
+# ─────────────────────────────────────────────────────────────────────────────
+name: databricks-cicd
+
+on:
+  push:
+    branches:
+      - 'feature/**'        # feature branch push → validate + deploy to dev
+      - main                # merge/push to main   → deploy to prod
+  pull_request:
+    branches: [main]        # PR targeting main     → validate-only merge gate
+
+jobs:
+  # 1. Feature-branch push → validate + deploy to DEV ──────────────────────────
+  dev:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/feature/')
+    runs-on: ubuntu-latest
+    env:
+      DATABRICKS_HOST: ${{ secrets.DEV_DATABRICKS_HOST }}
+      DATABRICKS_CLIENT_ID: ${{ secrets.DEV_CLIENT_ID }}
+      DATABRICKS_CLIENT_SECRET: ${{ secrets.DEV_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+      # Installs the modern Databricks CLI (NOT the deprecated pip package).
+      - uses: databricks/setup-cli@main
+      - name: Validate (dev)
+        run: databricks bundle validate -t dev --var warehouse_id=${{ secrets.DEV_WAREHOUSE_ID }}
+      # 3-PHASE DEPLOY — the Genie space validates its tables at deploy time, but
+      # the setup job builds those tables at run time. So: deploy everything
+      # EXCEPT Genie → run the job to build tables → full deploy (adds Genie).
+      - name: Phase 1 — deploy all except Genie (dev)
+        run: databricks bundle deploy -t dev --var warehouse_id=${{ secrets.DEV_WAREHOUSE_ID }} --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup
+      - name: Phase 2 — run setup job to build tables (dev)
+        run: databricks bundle run -t dev customer360_setup --var warehouse_id=${{ secrets.DEV_WAREHOUSE_ID }}
+      - name: Phase 3 — full deploy incl. Genie (dev)
+        run: databricks bundle deploy -t dev --var warehouse_id=${{ secrets.DEV_WAREHOUSE_ID }}
+
+  # 2. Pull request → main → VALIDATE only (merge gate, no deploy) ──────────────
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      DATABRICKS_HOST: ${{ secrets.DEV_DATABRICKS_HOST }}
+      DATABRICKS_CLIENT_ID: ${{ secrets.DEV_CLIENT_ID }}
+      DATABRICKS_CLIENT_SECRET: ${{ secrets.DEV_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: databricks/setup-cli@main
+      - name: Validate (dev)
+        run: databricks bundle validate -t dev --var warehouse_id=${{ secrets.DEV_WAREHOUSE_ID }}
+
+  # 3. Merge/push to main → deploy to PROD as the service principal ────────────
+  prod:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      DATABRICKS_HOST: ${{ secrets.PROD_DATABRICKS_HOST }}
+      DATABRICKS_CLIENT_ID: ${{ secrets.PROD_CLIENT_ID }}
+      DATABRICKS_CLIENT_SECRET: ${{ secrets.PROD_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: databricks/setup-cli@main
+      # prod deploys + runs as a service principal — run_as.service_principal_name
+      # must be the SP's application ID, which for an OAuth M2M SP is the same as
+      # its client id (PROD_CLIENT_ID). Pass it via --var prod_service_principal.
+      - name: Validate (prod)
+        run: databricks bundle validate -t prod --var warehouse_id=${{ secrets.PROD_WAREHOUSE_ID }} --var prod_service_principal=${{ secrets.PROD_CLIENT_ID }}
+      # 3-phase deploy (see the dev job for why).
+      - name: Phase 1 — deploy all except Genie (prod)
+        run: databricks bundle deploy -t prod --var warehouse_id=${{ secrets.PROD_WAREHOUSE_ID }} --var prod_service_principal=${{ secrets.PROD_CLIENT_ID }} --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup
+      - name: Phase 2 — run setup job to build tables (prod)
+        run: databricks bundle run -t prod customer360_setup --var warehouse_id=${{ secrets.PROD_WAREHOUSE_ID }} --var prod_service_principal=${{ secrets.PROD_CLIENT_ID }}
+      - name: Phase 3 — full deploy incl. Genie (prod)
+        run: databricks bundle deploy -t prod --var warehouse_id=${{ secrets.PROD_WAREHOUSE_ID }} --var prod_service_principal=${{ secrets.PROD_CLIENT_ID }}

--- a/core-platform/cicd/customer-360-lakehouse-genie/.gitignore
+++ b/core-platform/cicd/customer-360-lakehouse-genie/.gitignore
@@ -1,0 +1,12 @@
+# Databricks Asset Bundle local state (per-user, per-workspace — never commit)
+.databricks/
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# OS / editor cruft
+.DS_Store
+*.swp

--- a/core-platform/cicd/customer-360-lakehouse-genie/.gitlab-ci.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/.gitlab-ci.yml
@@ -1,0 +1,74 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# GitLab CI/CD for the Customer 360 Lakehouse bundle.
+#
+# STRATEGY (same across all four CI platforms in this repo) — the full lifecycle:
+#   1. Push to a feature branch  → validate + DEPLOY to the DEV workspace
+#                                  (inner loop; dev + prod are separate workspaces).
+#   2. Merge request → main      → VALIDATE only (cheap, no-compute merge gate).
+#   3. Commit to main            → DEPLOY to PROD as a SERVICE PRINCIPAL.
+#
+# AUTH: OAuth M2M. The CLI reads DATABRICKS_HOST / DATABRICKS_CLIENT_ID /
+# DATABRICKS_CLIENT_SECRET. Store the *_CLIENT_ID / *_CLIENT_SECRET as MASKED +
+# PROTECTED CI/CD variables (Settings → CI/CD → Variables), one SP per env.
+#
+# NOTE: uses the official Databricks CLI Docker image — do NOT `pip install
+# databricks-cli` (deprecated legacy CLI). GitLab has no official Databricks
+# CI/CD reference page; this follows the standard CLI pattern. Adjust the
+# feature-branch pattern (/^feature\//) to your team's convention.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Every job runs in a container that already has the Databricks CLI installed.
+image: ghcr.io/databricks/cli:latest
+
+stages:
+  - dev
+  - validate
+  - prod
+
+# 1. Feature-branch push → validate + deploy to DEV ─────────────────────────
+deploy_dev:
+  stage: dev
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^feature\//
+  variables:
+    DATABRICKS_HOST: $DEV_DATABRICKS_HOST
+    DATABRICKS_CLIENT_ID: $DEV_CLIENT_ID
+    DATABRICKS_CLIENT_SECRET: $DEV_CLIENT_SECRET
+  # 3-phase deploy: all-except-Genie → run setup job (builds tables) → full
+  # deploy (adds Genie). genie_spaces validates tables at deploy; job builds
+  # them at run. See AGENTS.md.
+  script:
+    - databricks bundle validate -t dev --var warehouse_id=$DEV_WAREHOUSE_ID
+    - databricks bundle deploy   -t dev --var warehouse_id=$DEV_WAREHOUSE_ID --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup
+    - databricks bundle run      -t dev customer360_setup --var warehouse_id=$DEV_WAREHOUSE_ID
+    - databricks bundle deploy   -t dev --var warehouse_id=$DEV_WAREHOUSE_ID
+
+# 2. Merge request → main → VALIDATE only (merge gate, no deploy) ────────────
+validate_mr:
+  stage: validate
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  variables:
+    DATABRICKS_HOST: $DEV_DATABRICKS_HOST
+    DATABRICKS_CLIENT_ID: $DEV_CLIENT_ID
+    DATABRICKS_CLIENT_SECRET: $DEV_CLIENT_SECRET
+  script:
+    - databricks bundle validate -t dev --var warehouse_id=$DEV_WAREHOUSE_ID
+
+# 3. Commit to main → deploy to PROD as the service principal ────────────────
+deploy_prod:
+  stage: prod
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  variables:
+    DATABRICKS_HOST: $PROD_DATABRICKS_HOST
+    DATABRICKS_CLIENT_ID: $PROD_CLIENT_ID
+    DATABRICKS_CLIENT_SECRET: $PROD_CLIENT_SECRET
+  # 3-phase deploy (see deploy_dev). run_as.service_principal_name must be the
+  # SP's application ID = its OAuth client id ($PROD_CLIENT_ID), passed via
+  # --var prod_service_principal.
+  script:
+    - databricks bundle validate -t prod --var warehouse_id=$PROD_WAREHOUSE_ID --var prod_service_principal=$PROD_CLIENT_ID
+    - databricks bundle deploy   -t prod --var warehouse_id=$PROD_WAREHOUSE_ID --var prod_service_principal=$PROD_CLIENT_ID --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup
+    - databricks bundle run      -t prod customer360_setup --var warehouse_id=$PROD_WAREHOUSE_ID --var prod_service_principal=$PROD_CLIENT_ID
+    - databricks bundle deploy   -t prod --var warehouse_id=$PROD_WAREHOUSE_ID --var prod_service_principal=$PROD_CLIENT_ID

--- a/core-platform/cicd/customer-360-lakehouse-genie/AGENTS.md
+++ b/core-platform/cicd/customer-360-lakehouse-genie/AGENTS.md
@@ -1,0 +1,154 @@
+# Deploy — Customer 360 Lakehouse
+
+Workflow-only example (no app or serving components). Because of a `genie_spaces`
+ordering constraint, deploy is a **3-phase flow** (deploy all-except-Genie → run
+the setup job to build the tables → full deploy adds Genie) — see the section
+below. `deploy` creates the resources (schema, volume, pipeline, dashboard, Genie
+space, setup job); `run` executes the setup job that builds/populates them.
+
+## Prerequisites
+- Databricks CLI **v1.3.0+** (required for the `genie_spaces` resource + `engine: direct`).
+- A CLI profile with workspace auth (`--profile <name>` or `DATABRICKS_CONFIG_PROFILE`).
+- A SQL Warehouse ID (powers the dashboard + Genie space).
+
+## Deploy — a 3-phase flow (important: read this)
+
+This bundle deploys in **three steps**, not one — because of how the Genie space
+resource works. The `genie_spaces` resource **validates that its bound tables
+exist at deploy time**, but those tables are *built by the setup job at run
+time*. So a plain `bundle deploy` fails on the Genie space (its tables don't
+exist yet). The fix: deploy everything **except** Genie, run the job to build the
+tables, then deploy again to add Genie. See **Known limitations** in the README.
+
+### Deploy (dev)
+
+```bash
+# Phase 1 — deploy everything EXCEPT the Genie space (its tables don't exist yet).
+databricks bundle deploy -t dev --var warehouse_id=<your-warehouse-id> \
+  --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup
+
+# Phase 2 — run the setup job to BUILD the tables:
+#           generate_data → run_pipeline → deploy_metric_view + validate_metrics
+databricks bundle run -t dev customer360_setup --var warehouse_id=<your-warehouse-id>
+
+# Phase 3 — full deploy: the Genie space's tables now exist, so it validates + creates.
+databricks bundle deploy -t dev --var warehouse_id=<your-warehouse-id>
+```
+
+`dev` is the default target — host comes from your CLI profile (`--profile …`).
+`catalog` ships as the placeholder `<your_catalog>`; `schema` defaults to
+`customer_360_demo`. **Before your first deploy, set `catalog` (in `databricks.yml`
+or via `--var catalog=…`) to an existing catalog AND edit the `identifier` values
+in `src/genie/genie_space.json` to the same catalog** — the Genie space's table
+references are hardcoded there (the `genie_spaces` resource does not substitute
+`${var...}` into its `file_path` JSON), so the two must agree or the space's
+tables won't resolve (see README "Known limitations"). Once set, keep it fixed:
+dev and prod are isolated at the **workspace level** (separate workspaces), both
+using the same catalog/schema.
+
+### Deploy (prod)
+
+Prod is a **separate workspace** and runs as a **service principal**. Same
+3-phase flow. Point the CLI at the prod workspace with the **`DATABRICKS_HOST`
+env var** (`workspace.host` can't be `${var}`-interpolated — this is what the
+CI/CD pipelines do), and set the SP application ID via `--var
+prod_service_principal=<app-id>`:
+
+```bash
+# Point at the prod workspace (auth via OAuth M2M — see CI/CD below).
+export DATABRICKS_HOST=https://<your-prod-workspace>.cloud.databricks.com
+export DATABRICKS_CLIENT_ID=<prod-sp-application-id>
+export DATABRICKS_CLIENT_SECRET=<prod-sp-oauth-secret>
+
+# Phase 1 — everything except Genie
+databricks bundle deploy -t prod \
+  --var warehouse_id=<id> \
+  --var prod_service_principal=<prod-sp-application-id> \
+  --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup
+
+# Phase 2 — build the tables
+databricks bundle run -t prod customer360_setup --var warehouse_id=<id> \
+  --var prod_service_principal=<prod-sp-application-id>
+
+# Phase 3 — full deploy (adds Genie)
+databricks bundle deploy -t prod \
+  --var warehouse_id=<id> \
+  --var prod_service_principal=<prod-sp-application-id>
+```
+
+> Alternatively, use a CLI `--profile <prod>` whose host is the prod workspace
+> instead of the `DATABRICKS_HOST` export. Either way, don't set `workspace.host`
+> in `databricks.yml` — a literal there would override this.
+
+Prod uses the same catalog/schema (isolation is by workspace, not by name) and
+`run_as` the service principal — so the identity that deploys is the identity
+that runs the deployed jobs/pipelines. Set `prod_service_principal` to that SP's
+application ID (it must match the SP whose OAuth credentials you authenticate
+with).
+
+## CI/CD (GitHub Actions, Azure DevOps, GitLab, Jenkins)
+
+This bundle ships ready-to-use CI/CD pipelines for four platforms — pick the one
+that matches your stack:
+
+| Platform | File |
+|---|---|
+| GitHub Actions | `.github/workflows/deploy.yml` |
+| Azure DevOps   | `azure-pipelines.yml` |
+| GitLab         | `.gitlab-ci.yml` |
+| Jenkins        | `Jenkinsfile` |
+
+**What they do (same strategy in all four — the full lifecycle):**
+1. **Push to a `feature/**` branch** → `validate` + `deploy -t dev` (your inner loop).
+2. **Pull request → `main`** → `validate` only (a cheap, no-compute merge gate).
+3. **Merge/push to `main`** → `deploy -t prod`, authenticated **as a service principal**.
+
+**Auth — OAuth machine-to-machine (M2M).** The CLI reads three environment
+variables per environment: `DATABRICKS_HOST`, `DATABRICKS_CLIENT_ID`,
+`DATABRICKS_CLIENT_SECRET`. Use **one service principal per environment** (a dev
+SP and a prod SP). The prod SP is also the `run_as` identity, so the deploying
+identity is the one that runs the deployed jobs/pipelines: the prod pipelines
+pass `--var prod_service_principal=$PROD_CLIENT_ID` (a SP's OAuth **client id** is
+its **application id**), which sets `run_as.service_principal_name` on the `prod`
+target automatically — you don't configure it separately.
+
+**Secrets to configure** (in your CI platform's secret store):
+
+| Purpose | GitHub / Azure / GitLab variable | Jenkins credential ID |
+|---|---|---|
+| Dev workspace URL | `DEV_DATABRICKS_HOST` | `dev-databricks-host` |
+| Dev SP application ID | `DEV_CLIENT_ID` | `dev-databricks-client-id` |
+| Dev SP OAuth secret | `DEV_CLIENT_SECRET` | `dev-databricks-client-secret` |
+| Dev SQL warehouse ID | `DEV_WAREHOUSE_ID` | `dev-databricks-warehouse-id` |
+| Prod workspace URL | `PROD_DATABRICKS_HOST` | `prod-databricks-host` |
+| Prod SP application ID | `PROD_CLIENT_ID` | `prod-databricks-client-id` |
+| Prod SP OAuth secret | `PROD_CLIENT_SECRET` | `prod-databricks-client-secret` |
+| Prod SQL warehouse ID | `PROD_WAREHOUSE_ID` | `prod-databricks-warehouse-id` |
+
+Where to store them: **GitHub** → Settings → Secrets and variables → Actions.
+**Azure DevOps** → Pipeline → Edit → Variables (mark secret). **GitLab** →
+Settings → CI/CD → Variables (masked + protected). **Jenkins** → Manage Jenkins →
+Credentials (Secret text, one per ID above; requires a *multibranch* pipeline).
+
+**Notes:**
+- Adjust the `feature/**` branch glob in each file to your team's branch convention.
+- **GitLab** has no official Databricks CI/CD reference — that file follows the
+  standard CLI pattern (and uses the official CLI image, not `pip install`).
+- **Public-repo / fork caution:** don't let PRs from untrusted forks trigger a
+  deploy — that would expose your SP secrets. Harden before enabling on a public repo.
+
+## Re-runs
+All phases are idempotent. Once the tables exist, a routine content change just
+needs a single `bundle deploy` (Phase 3) — the Genie space is a native
+`genie_spaces` resource, so `bundle deploy` reconciles it in place. Re-run the
+setup job (Phase 2) as well if the generated data or the metric view changed. You
+only need the full 3-phase sequence again on a clean workspace where the tables
+don't yet exist.
+
+## Teardown
+```bash
+databricks bundle destroy            # add -t prod for the prod target
+```
+Removes the bundle-managed resources (pipeline, dashboard, Genie space, and job).
+Does NOT drop the UC schema/tables/volume (delete those manually if you want a
+full cleanup).

--- a/core-platform/cicd/customer-360-lakehouse-genie/Jenkinsfile
+++ b/core-platform/cicd/customer-360-lakehouse-genie/Jenkinsfile
@@ -1,0 +1,86 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Jenkins CI/CD for the Customer 360 Lakehouse bundle.
+//
+// STRATEGY (same across all four CI platforms in this repo) — the full lifecycle:
+//   1. Push to a feature branch  → validate + DEPLOY to the DEV workspace
+//                                  (inner loop; dev + prod are separate workspaces).
+//   2. Pull request → main       → VALIDATE only (cheap, no-compute merge gate).
+//   3. Merge/push to main        → DEPLOY to PROD as a SERVICE PRINCIPAL.
+//
+// AUTH: OAuth M2M. The CLI reads DATABRICKS_HOST / DATABRICKS_CLIENT_ID /
+// DATABRICKS_CLIENT_SECRET. Store each SP's host + client id + secret as Jenkins
+// credentials (Manage Jenkins → Credentials), one set per environment, mapped
+// with withCredentials below. Requires the Databricks CLI Docker image and a
+// MULTIBRANCH pipeline (so env.BRANCH_NAME / env.CHANGE_ID are populated).
+//
+// `env.CHANGE_ID` is set ONLY for pull requests; `env.BRANCH_NAME` is the branch
+// for branch builds. Adjust the feature-branch match to your team's convention.
+// ─────────────────────────────────────────────────────────────────────────────
+pipeline {
+  // Run inside the official Databricks CLI image (CLI pre-installed).
+  agent { docker { image 'ghcr.io/databricks/cli:latest' } }
+
+  stages {
+    // 1. Feature-branch push → validate + deploy to DEV ──────────────────────
+    stage('Deploy (dev)') {
+      when {
+        allOf {
+          not { changeRequest() }                 // not a PR build
+          branch 'feature/*'                       // a feature branch
+        }
+      }
+      steps {
+        withCredentials([
+          string(credentialsId: 'dev-databricks-host',          variable: 'DATABRICKS_HOST'),
+          string(credentialsId: 'dev-databricks-client-id',     variable: 'DATABRICKS_CLIENT_ID'),
+          string(credentialsId: 'dev-databricks-client-secret', variable: 'DATABRICKS_CLIENT_SECRET'),
+          string(credentialsId: 'dev-databricks-warehouse-id',  variable: 'DATABRICKS_WAREHOUSE_ID')
+        ]) {
+          // 3-phase deploy: all-except-Genie → run setup job (builds tables) →
+          // full deploy (adds Genie). genie_spaces validates tables at deploy;
+          // the job builds them at run. See AGENTS.md.
+          sh 'databricks bundle validate -t dev --var warehouse_id=$DATABRICKS_WAREHOUSE_ID'
+          sh 'databricks bundle deploy   -t dev --var warehouse_id=$DATABRICKS_WAREHOUSE_ID --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup'
+          sh 'databricks bundle run      -t dev customer360_setup --var warehouse_id=$DATABRICKS_WAREHOUSE_ID'
+          sh 'databricks bundle deploy   -t dev --var warehouse_id=$DATABRICKS_WAREHOUSE_ID'
+        }
+      }
+    }
+
+    // 2. Pull request → main → VALIDATE only (merge gate, no deploy) ──────────
+    stage('Validate (merge gate)') {
+      when { changeRequest(target: 'main') }       // true only for PRs into main
+      steps {
+        withCredentials([
+          string(credentialsId: 'dev-databricks-host',          variable: 'DATABRICKS_HOST'),
+          string(credentialsId: 'dev-databricks-client-id',     variable: 'DATABRICKS_CLIENT_ID'),
+          string(credentialsId: 'dev-databricks-client-secret', variable: 'DATABRICKS_CLIENT_SECRET'),
+          string(credentialsId: 'dev-databricks-warehouse-id',  variable: 'DATABRICKS_WAREHOUSE_ID')
+        ]) {
+          sh 'databricks bundle validate -t dev --var warehouse_id=$DATABRICKS_WAREHOUSE_ID'
+        }
+      }
+    }
+
+    // 3. Merge/push to main → deploy to PROD as the service principal ─────────
+    stage('Deploy (prod)') {
+      when { branch 'main' }                       // true only on the main branch
+      steps {
+        withCredentials([
+          string(credentialsId: 'prod-databricks-host',          variable: 'DATABRICKS_HOST'),
+          string(credentialsId: 'prod-databricks-client-id',     variable: 'DATABRICKS_CLIENT_ID'),
+          string(credentialsId: 'prod-databricks-client-secret', variable: 'DATABRICKS_CLIENT_SECRET'),
+          string(credentialsId: 'prod-databricks-warehouse-id',  variable: 'DATABRICKS_WAREHOUSE_ID')
+        ]) {
+          // 3-phase deploy (see the dev stage for why). run_as.service_principal_name
+          // must be the SP's application ID = its OAuth client id
+          // ($DATABRICKS_CLIENT_ID), passed via --var prod_service_principal.
+          sh 'databricks bundle validate -t prod --var warehouse_id=$DATABRICKS_WAREHOUSE_ID --var prod_service_principal=$DATABRICKS_CLIENT_ID'
+          sh 'databricks bundle deploy   -t prod --var warehouse_id=$DATABRICKS_WAREHOUSE_ID --var prod_service_principal=$DATABRICKS_CLIENT_ID --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup'
+          sh 'databricks bundle run      -t prod customer360_setup --var warehouse_id=$DATABRICKS_WAREHOUSE_ID --var prod_service_principal=$DATABRICKS_CLIENT_ID'
+          sh 'databricks bundle deploy   -t prod --var warehouse_id=$DATABRICKS_WAREHOUSE_ID --var prod_service_principal=$DATABRICKS_CLIENT_ID'
+        }
+      }
+    }
+  }
+}

--- a/core-platform/cicd/customer-360-lakehouse-genie/README.md
+++ b/core-platform/cicd/customer-360-lakehouse-genie/README.md
@@ -1,0 +1,107 @@
+# Customer 360 Lakehouse — Genie Agents with DABs, End to End
+
+## The Story
+
+| | |
+|---|---|
+| **Company** | Vela Cloud — B2B software company, 30,000 accounts |
+| **Hero** | Maya Patel, VP of Customer Experience (owns support cost, renewal risk, exec reporting) |
+| **Problem** | 3 weeks ago churn risk jumped to 3x normal — a $1.4M renewal is now at risk |
+| **Investigation** | Maya compares regions in AI/BI, then asks Genie *"why is churn risk spiking?"* — traces it to delayed shipments driving a support-case surge |
+| **Root cause** | A carrier/fulfillment slip in the **EMEA** region blew out order lead times; late orders spawned unresolved support cases, which spiked churn risk on the largest EMEA renewals |
+| **Impact** | $1.4M renewal at risk, churn-risk index 3x normal (peaked ~3 weeks ago, still elevated), on-time delivery in EMEA dropped from ~92% to ~55% |
+
+---
+
+## Overview
+
+Maya owns the number leadership actually watches: net renewal dollars. Three weeks ago her churn-risk index tripled and a $1.4M EMEA renewal lit up red. The problem: the answer lived in three disconnected reports — CRM accounts, the support queue, and the order/fulfillment feed — and nobody could stitch them together fast enough.
+
+This demo tells the **end-to-end Customer 360 Lakehouse** story: synthetic CRM, case, and order feeds land through **Lakeflow Connect** with incremental ingestion and data-quality **expectations**, **Lakeflow Jobs** orchestrates the refresh into **Spark Declarative Pipelines** (Bronze → Silver → Gold) and governed **Metric Views**, and in **AI/BI** Maya compares regions, spots that delayed shipments are driving the support surge, and asks **Genie** which account segments are most exposed. **Genie One** lets her ask follow-up business questions in plain English; **Genie Code** helped the team build the governed KPI layer and dashboard faster. One governed customer view instead of three reports — analysis goes from days to minutes.
+
+**Duration:** 6–8 minutes
+
+---
+
+## Key Numbers
+
+| Metric | Value |
+|--------|-------|
+| Accounts | 30,000 (CRM) |
+| Regions | NA, EMEA, APAC, LATAM |
+| Normal churn-risk index | ~1.0x baseline |
+| Peak churn-risk index (~3 weeks ago) | ~3.0x (EMEA-led, still elevated) |
+| Renewal at risk | $1.4M (top EMEA Enterprise accounts) |
+| EMEA on-time delivery | ~92% → ~55% during the slip |
+| Support case surge | EMEA unresolved cases ~3x baseline in the affected window |
+
+---
+
+## Demo Walkthrough
+
+**Frame:** Monday exec review. Maya's renewal-risk tile is red and leadership wants an explanation, not three separate reports.
+
+### Act 1 — Fresh, governed data (1–2 min)
+Show the **Lakeflow Job** that orchestrates the run and the **SDP pipeline** graph: raw CRM/case/order feeds ingested incrementally (Auto Loader) with **expectations** dropping bad rows, flowing Bronze → Silver → Gold. Point at the **Metric Views** — churn-risk index, on-time delivery %, renewal-at-risk $ defined once, governed by **Unity Catalog**.
+
+> *"Lakeflow Connect pulls CRM, support, and ERP with no custom plumbing. SDP shapes it into Gold with data-quality expectations enforced in the pipeline. Metric Views define the KPIs once so every consumer agrees on the number."*
+
+### Act 2 — See it in AI/BI (2 min)
+Open the **Customer 360** dashboard. The churn-risk trend spikes ~3 weeks ago; a region breakdown makes **EMEA** jump off the page. A second row lines up **on-time delivery** collapsing in EMEA against **unresolved cases** rising — same shape, same window.
+
+> *"The 5-second test: churn risk tripled, and it's EMEA. Delayed shipments and the case surge move together."*
+
+### Act 3 — Ask Genie why (2 min)
+In the dashboard's **Genie** space, Maya types *"Which account segments are most exposed to the churn-risk spike?"* Genie returns EMEA **Enterprise** accounts up for renewal, with the **$1.4M** at-risk total. Follow-up: *"Show on-time delivery vs case volume for those accounts over the last 8 weeks."*
+
+> *"Genie turns plain English into governed SQL over the same Metric Views — trusted answers, not a guess. **Genie One** is the front door for business users; **Genie Code** is how the team built this KPI layer and dashboard fast."*
+
+### Closing
+> One end-to-end Customer 360 Lakehouse: fresh incremental data with expectations, reusable governed KPIs, dashboards, and an agent-ready Genie space — all packaged as a Databricks Asset Bundle. Analysis went from days to minutes, and the $1.4M renewal now has an owner and a plan.
+
+---
+
+## Known limitations
+
+These two limitations both come from the current `genie_spaces` DABs resource —
+every other resource in this bundle is fully parameterized and deploys in one
+shot.
+
+**1. Deploy is a 3-phase flow, not one command.** The `genie_spaces` resource
+**validates that its bound tables exist at deploy time**, but those tables are
+*built by the setup job at run time*. A plain `bundle deploy` therefore fails on
+the Genie space (its tables don't exist yet). The fix: deploy everything **except**
+Genie, run the setup job to build the tables, then deploy again to add Genie —
+see the 3-phase flow in **AGENTS.md** (and the CI/CD pipelines encode the same
+three steps).
+
+**2. The Genie space's table binding is static — edit the JSON before you deploy.**
+`src/genie/genie_space.json` ships with placeholder table references
+(`<your_catalog>.customer_360_demo.*`). **Before your first deploy, set the
+`catalog` variable in `databricks.yml` (or pass `--var catalog=…`) AND edit the
+`identifier` values in `src/genie/genie_space.json` to the same catalog** — the two
+must agree or the Genie space's tables won't resolve. Both the `dev` and `prod`
+targets deploy to that same catalog/schema — isolation is at the **workspace
+level** (dev and prod are separate workspaces/metastores), not by using different
+catalog/schema names, which is what keeps the single static binding valid in both.
+
+The reason the binding can't be parameterized: the Databricks CLI deploys a
+`genie_spaces` `file_path` JSON **verbatim** (no `${var.catalog}`/`${var.schema}`
+substitution inside the file), and the `genie_spaces` resource has **no
+`dataset_catalog`/`dataset_schema` field** to rebind tables per target — unlike
+the `dashboards` resource, which does. So the JSON's `catalog.schema` must be
+edited by hand whenever you change the `catalog`/`schema` variables.
+
+## Products Showcased
+
+| Product | Mode | What it does in this demo |
+|---------|------|---------------------------|
+| **Lakeflow Connect** | Talk track | Ingests CRM accounts, support cases, and orders with incremental (Auto Loader) ingestion — no custom pipelines |
+| **SDP Pipeline** | Build | Bronze → Silver → Gold with data-quality expectations; produces the governed customer-360 Gold tables |
+| **Lakeflow Jobs** | Build | Orchestrates the end-to-end refresh (data gen → pipeline) with retries and scheduling |
+| **Metric Views** | Build | Governed KPI layer — churn-risk index, on-time delivery %, renewal-at-risk $ defined once, used by dashboard and Genie |
+| **AI/BI Dashboard** | Build | The churn-risk spike and EMEA delivery collapse at a glance — the 5-second test |
+| **AI/BI Genie** | Build | Answers *"which segments are most exposed?"* — natural language to governed SQL over the Metric Views |
+| **Genie One** | Talk track | Business-user front door for plain-English follow-up questions |
+| **Genie Code** | Talk track | How the team built the KPI layer and dashboard faster on the lakehouse |
+| **Unity Catalog** | Talk track | One permission + lineage model across ingestion, pipeline, metrics, dashboard, and Genie |

--- a/core-platform/cicd/customer-360-lakehouse-genie/architecture.md
+++ b/core-platform/cicd/customer-360-lakehouse-genie/architecture.md
@@ -1,0 +1,47 @@
+```json
+[
+  {
+    "name": "Customer 360 Lakehouse",
+    "story": "Vela Cloud ingests CRM accounts, orders and support cases via Lakeflow Connect into a governed Spark Declarative Pipeline (bronze→silver→gold), orchestrated by Lakeflow Jobs. A governed Metric View defines the KPIs once, powering an AI/BI dashboard and a Genie Agent so Maya (VP Customer Experience) can spot the EMEA churn spike and ask follow-ups in plain language — reached through Genie One, all on the governed Databricks platform.",
+    "columns": ["sources", "pipeline", "compute", "work", "entry"],
+    "nodes": [
+      { "id": "src-salesforce", "type": "source", "col": "sources", "row": 1, "label": "Salesforce", "icon": "file:vendor/salesforce", "desc": "CRM accounts, ARR, renewals" },
+      { "id": "src-sap", "type": "source", "col": "sources", "row": 2, "label": "SAP", "icon": "file:vendor/sap", "desc": "Order & shipment data" },
+      { "id": "src-zendesk", "type": "source", "col": "sources", "row": 3, "label": "Zendesk", "icon": "file:vendor/zendesk", "desc": "Support cases" },
+
+      { "id": "lakeflow-genie-block", "type": "lakeflow-genie-block", "col": "pipeline", "row": 1 },
+      { "id": "lakeflow-jobs", "type": "lakeflow-jobs", "col": "pipeline", "row": 2, "desc": "Scheduled orchestration: land → pipeline → refresh metrics", "note": "Orchestrates the pipeline nightly for the Monday exec review." },
+
+      { "id": "sql-lakehouse", "type": "sql-lakehouse", "col": "compute", "row": 1 },
+      { "id": "metric-views", "type": "metric-views", "col": "compute", "row": 2, "note": "mv_customer_health — governed KPI layer (churn index, on-time rate, ARR at risk) used by BOTH the dashboard and Genie so numbers match." },
+
+      { "id": "ai-bi-dashboard", "type": "ai-bi-dashboard", "col": "work", "row": 1 },
+      { "id": "genie", "type": "genie", "col": "work", "row": 2 },
+
+      { "id": "genie-one", "type": "genie-one", "col": "entry", "rot": 90 },
+
+      { "id": "db-platform", "type": "db-platform", "pin": { "at": "top-left", "to": "platform-box" } },
+      { "id": "governance-block", "type": "governance-block", "pin": { "at": "top-right", "to": "platform-box" } },
+
+      { "id": "platform-box", "type": "box", "z": -1,
+        "wraps": ["src-salesforce", "src-sap", "src-zendesk", "lakeflow-genie-block", "lakeflow-jobs", "sql-lakehouse", "metric-views", "ai-bi-dashboard", "genie", "genie-one"] }
+    ],
+    "edges": [
+      { "id": "e1", "from": "src-salesforce", "to": "lakeflow-genie-block@in-lakeflow-connect", "flow": true },
+      { "id": "e2", "from": "src-sap", "to": "lakeflow-genie-block@in-lakeflow-connect", "flow": true },
+      { "id": "e3", "from": "src-zendesk", "to": "lakeflow-genie-block@in-lakeflow-connect", "flow": true },
+
+      { "id": "e4", "from": "lakeflow-jobs", "to": "lakeflow-genie-block", "arrow": "end", "dashed": true, "label": "orchestrates" },
+
+      { "id": "e5", "from": "lakeflow-genie-block", "to": "sql-lakehouse", "flow": true },
+      { "id": "e6", "from": "sql-lakehouse", "to": "metric-views", "flow": true },
+
+      { "id": "e7", "from": "metric-views", "to": "ai-bi-dashboard", "flow": true },
+      { "id": "e8", "from": "metric-views", "to": "genie", "flow": true },
+
+      { "id": "e9", "from": "genie-one", "to": "ai-bi-dashboard" },
+      { "id": "e10", "from": "genie-one", "to": "genie" }
+    ]
+  }
+]
+```

--- a/core-platform/cicd/customer-360-lakehouse-genie/azure-pipelines.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/azure-pipelines.yml
@@ -1,0 +1,74 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Azure DevOps CI/CD for the Customer 360 Lakehouse bundle.
+#
+# STRATEGY (same across all four CI platforms in this repo) — the full lifecycle:
+#   1. Push to a feature branch  → validate + DEPLOY to the DEV workspace
+#                                  (inner loop; dev + prod are separate workspaces).
+#   2. Pull request → main       → VALIDATE only (cheap, no-compute merge gate).
+#   3. Merge/push to main        → DEPLOY to PROD as a SERVICE PRINCIPAL.
+#
+# AUTH: OAuth M2M. The CLI reads DATABRICKS_HOST / DATABRICKS_CLIENT_ID /
+# DATABRICKS_CLIENT_SECRET. Store the *_CLIENT_ID / *_CLIENT_SECRET as SECRET
+# pipeline variables ("Keep this value secret"), one SP per environment. Secret
+# variables are mapped explicitly under each step's `env:` below.
+#
+# NOTE: adjust the feature-branch glob ('feature/*') to your team's convention.
+# ─────────────────────────────────────────────────────────────────────────────
+
+trigger:
+  branches:
+    include:
+      - main                # merge/push to main   → deploy to prod
+      - feature/*           # feature branch push  → validate + deploy to dev
+
+pr:
+  branches:
+    include: [main]         # PR targeting main     → validate-only merge gate
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  # Install the modern Databricks CLI (NOT the deprecated pip package).
+  - script: curl -fsSL https://raw.githubusercontent.com/databricks/cli/main/install.sh | sh
+    displayName: Install Databricks CLI
+
+  # 1. Feature-branch push → validate + 3-phase deploy to DEV ─────────────────
+  #    3-phase: deploy all-except-Genie → run setup job (builds tables) → full
+  #    deploy (adds Genie). Required because genie_spaces validates its tables at
+  #    deploy time but the job builds them at run time. See AGENTS.md.
+  - script: |
+      databricks bundle validate -t dev --var warehouse_id=$(DEV_WAREHOUSE_ID)
+      databricks bundle deploy   -t dev --var warehouse_id=$(DEV_WAREHOUSE_ID) --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup
+      databricks bundle run      -t dev customer360_setup --var warehouse_id=$(DEV_WAREHOUSE_ID)
+      databricks bundle deploy   -t dev --var warehouse_id=$(DEV_WAREHOUSE_ID)
+    displayName: Validate + 3-phase Deploy (dev)
+    condition: and(ne(variables['Build.Reason'], 'PullRequest'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'))
+    env:
+      DATABRICKS_HOST: $(DEV_DATABRICKS_HOST)
+      DATABRICKS_CLIENT_ID: $(DEV_CLIENT_ID)
+      DATABRICKS_CLIENT_SECRET: $(DEV_CLIENT_SECRET)
+
+  # 2. Pull request → main → VALIDATE only (merge gate, no deploy) ─────────────
+  - script: databricks bundle validate -t dev --var warehouse_id=$(DEV_WAREHOUSE_ID)
+    displayName: Validate (merge gate)
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    env:
+      DATABRICKS_HOST: $(DEV_DATABRICKS_HOST)
+      DATABRICKS_CLIENT_ID: $(DEV_CLIENT_ID)
+      DATABRICKS_CLIENT_SECRET: $(DEV_CLIENT_SECRET)
+
+  # 3. Merge/push to main → 3-phase deploy to PROD as the service principal ───
+  #    run_as.service_principal_name must be the SP's application ID = its OAuth
+  #    client id (PROD_CLIENT_ID), passed via --var prod_service_principal.
+  - script: |
+      databricks bundle validate -t prod --var warehouse_id=$(PROD_WAREHOUSE_ID) --var prod_service_principal=$(PROD_CLIENT_ID)
+      databricks bundle deploy   -t prod --var warehouse_id=$(PROD_WAREHOUSE_ID) --var prod_service_principal=$(PROD_CLIENT_ID) --select schemas.customer360_schema,volumes.raw_data,pipelines.customer360_pipeline,dashboards.customer360_dashboard,jobs.customer360_setup
+      databricks bundle run      -t prod customer360_setup --var warehouse_id=$(PROD_WAREHOUSE_ID) --var prod_service_principal=$(PROD_CLIENT_ID)
+      databricks bundle deploy   -t prod --var warehouse_id=$(PROD_WAREHOUSE_ID) --var prod_service_principal=$(PROD_CLIENT_ID)
+    displayName: 3-phase Deploy (prod)
+    condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    env:
+      DATABRICKS_HOST: $(PROD_DATABRICKS_HOST)
+      DATABRICKS_CLIENT_ID: $(PROD_CLIENT_ID)
+      DATABRICKS_CLIENT_SECRET: $(PROD_CLIENT_SECRET)

--- a/core-platform/cicd/customer-360-lakehouse-genie/databricks.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/databricks.yml
@@ -1,0 +1,71 @@
+# Customer 360 Lakehouse — an end-to-end Databricks Asset Bundle example.
+#
+# WHAT THIS TEACHES: a complete Lakehouse project defined as a single bundle —
+# a Unity Catalog schema + volume, a Lakeflow Declarative Pipeline (Auto Loader
+# + expectations, bronze → silver → gold), a metric view, an AI/BI dashboard, a
+# Genie space, and an orchestration job that ties them together.
+#
+# HOW IT DEPLOYS: parametrized via --var (no hardcoded IDs). `bundle deploy`
+# creates the resource definitions (schema, volume, pipeline, dashboard, Genie
+# space, setup job); `bundle run customer360_setup` populates them:
+# generate_data → run_pipeline → deploy_metric_view → validate_metrics.
+#
+# Workflow-only example (no app or serving components). Deploy is a 3-PHASE flow
+# (the Genie space validates its tables at deploy time, but the setup job builds
+# them at run time), so a plain one-shot deploy won't work:
+#   1. databricks bundle deploy --select <everything except the Genie space> …
+#   2. databricks bundle run customer360_setup …   # builds the tables
+#   3. databricks bundle deploy …                  # full deploy, adds Genie
+# See AGENTS.md for the full agent-oriented deploy instructions.
+
+bundle:
+  name: customer_360_lakehouse
+  engine: direct   # required to deploy the `genie_spaces` resource (below)
+
+include:
+  - resources/*.yml
+
+variables:
+  catalog:
+    description: "Unity Catalog for demo resources"
+    # Set this to an existing catalog in your workspace before deploying. NOTE:
+    # if you change catalog/schema you MUST also edit the hardcoded identifiers
+    # in src/genie/genie_space.json to match — the genie_spaces resource does not
+    # substitute ${var...} into its file_path JSON. See README "Known limitations".
+    default: "<your_catalog>"
+  schema:
+    description: "Schema within the catalog (created by this bundle)"
+    default: "customer_360_demo"
+  warehouse_id:
+    description: "SQL Warehouse ID — powers the dashboard + Genie space"
+  prod_service_principal:
+    description: "Application ID of the SP that deploys AND runs prod"
+    default: "REPLACE-WITH-PROD-SP-APPLICATION-ID"
+
+sync:
+  include:
+    - "src/**"   # the sync block defines which files are synced to the workspace. Guarantees everything under src/ ships
+
+targets:
+  # ISOLATION MODEL: dev and prod are isolated at the WORKSPACE level (the
+  # Databricks-recommended practice) — separate workspaces/metastores, same
+  # catalog/schema NAME (<your_catalog>.customer_360_demo) in each. Because the
+  # workspaces are separate, reusing the name is safe, and it keeps every resource
+  # (incl. the Genie space, whose table refs are static) valid in both targets.
+
+  # dev = default target: host from your CLI profile (--profile). 3-phase deploy.
+  dev:
+    default: true
+  # prod = separate workspace, deploys + runs as a SERVICE PRINCIPAL.
+  # The prod workspace URL is NOT set here: workspace.host does not support
+  # ${var...} interpolation, and a literal host would override the CLI's auth
+  # resolution. Instead point at prod via the DATABRICKS_HOST env var (what the
+  # CI/CD pipelines do) or a `--profile` whose host is the prod workspace. Set the
+  # deploying/running SP with --var prod_service_principal=<app-id>. Uses the same
+  # <your_catalog>.customer_360_demo (isolation is by workspace, not by name).
+  prod:
+    mode: production
+    workspace:
+      root_path: /Workspace/Shared/.bundle/${bundle.name}/prod
+    run_as:
+      service_principal_name: ${var.prod_service_principal}

--- a/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_dashboard.dashboard.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_dashboard.dashboard.yml
@@ -1,0 +1,13 @@
+resources:
+  # ──────────────────────────────────────────────────────────────────────────
+  # AI/BI dashboard — dataset_catalog/dataset_schema rebind the embedded bare
+  # table names per-target (requires CLI v0.283.0+). The JSON ships with NO
+  # catalog/schema on its datasets.
+  # ──────────────────────────────────────────────────────────────────────────
+  dashboards:
+    customer360_dashboard:
+      display_name: "[${bundle.target}] Customer 360"
+      file_path: ../src/dashboard/dashboard.json
+      warehouse_id: ${var.warehouse_id}
+      dataset_catalog: ${resources.schemas.customer360_schema.catalog_name}
+      dataset_schema: ${resources.schemas.customer360_schema.name}

--- a/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_genie.genie_space.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_genie.genie_space.yml
@@ -1,0 +1,26 @@
+resources:
+  # ──────────────────────────────────────────────────────────────────────────
+  # Genie space — deployed as a NATIVE bundle resource (requires engine: direct,
+  # set above; CLI v1.3.0+). This is the headline of the example: a Genie Agent
+  # defined and deployed WITH DABs, not created imperatively via the SDK.
+  #
+  # NOTE — table binding is STATIC: genie_space.json ships with placeholder refs
+  # `<your_catalog>.customer_360_demo.*`. EDIT those identifiers to your catalog
+  # BEFORE deploying (and keep them in sync with the `catalog`/`schema` vars) —
+  # the CLI deploys a `file_path` JSON *verbatim* (no ${var} substitution inside
+  # it), and `genie_spaces` has no dataset_catalog/dataset_schema field to rebind
+  # tables per target (unlike the `dashboards` resource). Both dev and prod use
+  # that same catalog/schema (isolation is at the workspace level — see the
+  # targets block in databricks.yml).
+  #
+  # DEPLOY ORDERING: this resource validates that its bound tables EXIST at deploy
+  # time, but the setup job builds them at RUN time — so the bundle deploys in 3
+  # phases (all-except-Genie → run setup job → full deploy). See AGENTS.md / README
+  # "Known limitations".
+  # ──────────────────────────────────────────────────────────────────────────
+  genie_spaces:
+    customer360_genie:
+      title: "[${bundle.target}] Customer 360"
+      description: "Customer-360 analytics — walk the curated questions to trace the EMEA churn-risk spike back to the fulfillment slip."
+      file_path: ../src/genie/genie_space.json
+      warehouse_id: ${var.warehouse_id}

--- a/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_pipeline.pipeline.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_pipeline.pipeline.yml
@@ -1,0 +1,24 @@
+resources:
+  # ──────────────────────────────────────────────────────────────────────────
+  # SDP pipeline — Python bronze (Auto Loader + expectations) → SQL silver/gold.
+  # The bronze reads the landing volume from `demo.volume_path` (SQL read_files
+  # can't interpolate conf vars), resolved through the schema resource so it
+  # stays consistent with the data-gen task's catalog/schema.
+  # ──────────────────────────────────────────────────────────────────────────
+  pipelines:
+    customer360_pipeline:
+      name: "[${bundle.target}] Customer 360"
+      catalog: ${resources.schemas.customer360_schema.catalog_name}
+      target: ${resources.schemas.customer360_schema.name}
+      serverless: true
+      photon: true
+      channel: current
+      configuration:
+        demo.volume_path: "/Volumes/${resources.schemas.customer360_schema.catalog_name}/${resources.schemas.customer360_schema.name}/raw_data"
+      libraries:
+        - file:
+            path: ../src/pipeline/01_bronze.py
+        - file:
+            path: ../src/pipeline/02_silver.sql
+        - file:
+            path: ../src/pipeline/03_gold.sql

--- a/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_schema.schema.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_schema.schema.yml
@@ -1,0 +1,9 @@
+resources:
+  # ──────────────────────────────────────────────────────────────────────────
+  # Schema + raw landing volume
+  # ──────────────────────────────────────────────────────────────────────────
+  schemas:
+    customer360_schema:
+      name: ${var.schema}
+      catalog_name: ${var.catalog}
+      comment: "Customer 360 demo data"

--- a/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_setup.job.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/resources/customer360_setup.job.yml
@@ -1,0 +1,54 @@
+resources:
+  # ──────────────────────────────────────────────────────────────────────────
+  # Setup job — runs AFTER `bundle deploy` created the resources. Tasks pass
+  # catalog/schema via base_parameters using the RESOLVED schema name. A weekly
+  # (paused) schedule reflects the Monday-exec-review orchestration story.
+  # ──────────────────────────────────────────────────────────────────────────
+  jobs:
+    customer360_setup:
+      name: "[${bundle.target}] Customer 360 Setup"
+      description: "data → pipeline → metric view + validate"
+      schedule:
+        quartz_cron_expression: "0 0 6 ? * MON"
+        timezone_id: "UTC"
+        pause_status: PAUSED
+      tasks:
+        - task_key: generate_data
+          notebook_task:
+            notebook_path: ../src/data_generation/generate_data.py
+            base_parameters:
+              catalog: ${resources.schemas.customer360_schema.catalog_name}
+              schema:  ${resources.schemas.customer360_schema.name}
+          environment_key: sdk_default
+
+        - task_key: run_pipeline
+          depends_on: [{ task_key: generate_data }]
+          pipeline_task:
+            pipeline_id: ${resources.pipelines.customer360_pipeline.id}
+
+        # Metric views have no PySpark API — this notebook runs the
+        # `CREATE OR REPLACE VIEW … WITH METRICS LANGUAGE YAML` SQL inline.
+        - task_key: deploy_metric_view
+          depends_on: [{ task_key: run_pipeline }]
+          notebook_task:
+            notebook_path: ../src/metric_view/mv_customer_health.py
+            base_parameters:
+              catalog: ${resources.schemas.customer360_schema.catalog_name}
+              schema:  ${resources.schemas.customer360_schema.name}
+          environment_key: sdk_default
+
+        - task_key: validate_metrics
+          depends_on: [{ task_key: deploy_metric_view }]
+          notebook_task:
+            notebook_path: ../src/jobs/validate_metrics.py
+            base_parameters:
+              catalog: ${resources.schemas.customer360_schema.catalog_name}
+              schema:  ${resources.schemas.customer360_schema.name}
+          environment_key: sdk_default
+
+      environments:
+        - environment_key: sdk_default
+          spec:
+            client: "4"
+            dependencies:
+              - "numpy"

--- a/core-platform/cicd/customer-360-lakehouse-genie/resources/raw_data.volume.yml
+++ b/core-platform/cicd/customer-360-lakehouse-genie/resources/raw_data.volume.yml
@@ -1,0 +1,8 @@
+resources:
+  volumes:
+    raw_data:
+      catalog_name: ${var.catalog}
+      schema_name: ${var.schema}
+      name: "raw_data"
+      volume_type: "MANAGED"
+      comment: "Raw CRM/order/case parquet — the Lakeflow Connect landing zone"

--- a/core-platform/cicd/customer-360-lakehouse-genie/src/dashboard/dashboard.json
+++ b/core-platform/cicd/customer-360-lakehouse-genie/src/dashboard/dashboard.json
@@ -1,0 +1,426 @@
+{
+  "datasets": [
+    {
+      "name": "ds_metrics",
+      "displayName": "Customer health metrics",
+      "queryLines": [
+        "SELECT `date`, region, segment,\n",
+        "  MEASURE(`churn_risk_index`) AS churn_risk_index,\n",
+        "  MEASURE(`on_time_delivery_rate`) AS on_time_rate,\n",
+        "  MEASURE(`unresolved_cases`) AS unresolved_cases,\n",
+        "  MEASURE(`shipping_delay_cases`) AS shipping_delay_cases,\n",
+        "  MEASURE(`arr_at_risk`) AS arr_at_risk,\n",
+        "  MEASURE(`new_cases`) AS new_cases,\n",
+        "  MEASURE(`late_orders`) AS late_orders\n",
+        "FROM mv_customer_health\n",
+        "GROUP BY ALL"
+      ]
+    },
+    {
+      "name": "ds_accounts",
+      "displayName": "Account health",
+      "queryLines": [
+        "SELECT account_id, account_name, region, country, segment, industry,\n",
+        "  arr_usd, renewal_date, days_to_renewal, churn_risk_index, churn_risk_score,\n",
+        "  is_at_risk, open_cases_30d, late_orders_30d, on_time_rate_30d\n",
+        "FROM gold_account_health"
+      ],
+      "columns": [
+        {"displayName": "ARR at Risk", "description": "ARR of at-risk accounts", "expression": "SUM(CASE WHEN `is_at_risk` THEN `arr_usd` ELSE 0 END)"},
+        {"displayName": "Avg Churn Index", "description": "Average churn-risk index", "expression": "AVG(`churn_risk_index`)"}
+      ]
+    },
+    {
+      "name": "ds_at_risk",
+      "displayName": "At-risk EMEA Enterprise accounts",
+      "queryLines": [
+        "SELECT account_name, country, arr_usd, days_to_renewal, churn_risk_index,\n",
+        "  open_cases_30d, on_time_rate_30d\n",
+        "FROM gold_account_health\n",
+        "WHERE region = 'EMEA' AND segment = 'Enterprise' AND is_at_risk\n",
+        "ORDER BY arr_usd DESC"
+      ]
+    },
+    {
+      "name": "ds_cases",
+      "displayName": "EMEA cases by category",
+      "queryLines": [
+        "SELECT category, COUNT(*) AS case_count\n",
+        "FROM silver_cases\n",
+        "WHERE region = 'EMEA'\n",
+        "GROUP BY category ORDER BY case_count DESC"
+      ]
+    },
+    {
+      "name": "ds_forecast",
+      "displayName": "EMEA churn forecast",
+      "queryLines": [
+        "WITH actuals AS (\n",
+        "  SELECT date_trunc('WEEK', `date`) AS week, ROUND(MEASURE(`churn_risk_index`),3) AS churn\n",
+        "  FROM mv_customer_health\n",
+        "  WHERE region = 'EMEA' AND `date` >= date_sub(current_date(), 180)\n",
+        "    AND date_trunc('WEEK', `date`) < date_trunc('WEEK', current_date())\n",
+        "  GROUP BY 1\n",
+        "),\n",
+        "dates AS (SELECT MAX(week) AS max_d, MIN(week) AS min_d FROM actuals),\n",
+        "forecast AS (\n",
+        "  SELECT week, churn_forecast, churn_upper, churn_lower, CAST(NULL AS DOUBLE) AS churn\n",
+        "  FROM AI_FORECAST(TABLE(actuals),\n",
+        "    horizon => (SELECT max_d + MAKE_DT_INTERVAL(42,0,0,0) FROM dates),\n",
+        "    time_col => 'week', value_col => 'churn')\n",
+        "),\n",
+        "bridge AS (\n",
+        "  SELECT a.week, a.churn AS churn_forecast, a.churn AS churn_upper, a.churn AS churn_lower, a.churn\n",
+        "  FROM actuals a JOIN dates d ON a.week = d.max_d\n",
+        ")\n",
+        "SELECT week, CAST(NULL AS DOUBLE) AS churn_forecast, CAST(NULL AS DOUBLE) AS churn_upper, CAST(NULL AS DOUBLE) AS churn_lower, churn FROM actuals\n",
+        "UNION ALL SELECT week, churn_forecast, churn_upper, churn_lower, churn FROM bridge\n",
+        "UNION ALL SELECT week, churn_forecast, churn_upper, churn_lower, churn FROM forecast"
+      ]
+    }
+  ],
+  "pages": [
+    {
+      "name": "executive",
+      "displayName": "Executive",
+      "pageType": "PAGE_TYPE_CANVAS",
+      "layoutVersion": "GRID_V1",
+      "layout": [
+        {
+          "widget": {
+            "name": "exec-header",
+            "multilineTextboxSpec": {
+              "lines": [
+                "# Customer 360 — Executive\n",
+                "**Maya Patel, VP Customer Experience.** An EMEA fulfillment slip (~5 weeks ago) blew out shipping times; late orders drove a support surge and pushed churn risk to ~3x. **A $1.4M renewal is exposed.** This page tracks the shape and the recovery — watch the orange EMEA line tower over the flat NA/APAC/LATAM lines."
+              ]
+            }
+          },
+          "position": {"x": 0, "y": 0, "width": 12, "height": 2}
+        },
+        {
+          "widget": {
+            "name": "kpi-churn",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_metrics", "fields": [
+              {"name": "weekly(date)", "expression": "DATE_TRUNC(\"WEEK\", `date`)"},
+              {"name": "measure(churn)", "expression": "MEASURE(`churn_risk_index`)"}
+            ], "disaggregated": false, "orders": [{"direction": "DESC", "expression": "DATE_TRUNC(\"WEEK\", `date`)"}]}}],
+            "spec": {"version": 2, "widgetType": "counter", "frame": {"title": "Churn-risk index (weekly)", "showTitle": true},
+              "encodings": {
+                "value": {"fieldName": "measure(churn)", "displayName": "Churn-risk index", "rowNumber": 1, "format": {"type": "number", "decimalPlaces": {"type": "exact", "places": 2}}, "style": {"color": {"hex": "#FE9000"}}},
+                "period": {"fieldName": "weekly(date)"}
+              }}
+          },
+          "position": {"x": 0, "y": 2, "width": 3, "height": 3}
+        },
+        {
+          "widget": {
+            "name": "kpi-arr",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_accounts", "fields": [
+              {"name": "measure(ARR at Risk)", "expression": "MEASURE(`ARR at Risk`)"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 2, "widgetType": "counter", "frame": {"title": "ARR at risk", "showTitle": true},
+              "encodings": {"value": {"fieldName": "measure(ARR at Risk)", "displayName": "ARR at risk", "format": {"type": "number-currency", "currencyCode": "USD", "abbreviation": "compact", "decimalPlaces": {"type": "max", "places": 1}}, "style": {"color": {"hex": "#FE9000"}}}}}
+          },
+          "position": {"x": 3, "y": 2, "width": 3, "height": 3}
+        },
+        {
+          "widget": {
+            "name": "kpi-ontime",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_metrics", "fields": [
+              {"name": "measure(on_time)", "expression": "MEASURE(`on_time_delivery_rate`)"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 2, "widgetType": "counter", "frame": {"title": "On-time delivery", "showTitle": true},
+              "encodings": {"value": {"fieldName": "measure(on_time)", "displayName": "On-time delivery", "format": {"type": "number-percent", "decimalPlaces": {"type": "exact", "places": 1}}, "style": {"color": {"hex": "#094074"}}}}}
+          },
+          "position": {"x": 6, "y": 2, "width": 3, "height": 3}
+        },
+        {
+          "widget": {
+            "name": "kpi-cases",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_metrics", "fields": [
+              {"name": "measure(unresolved)", "expression": "MEASURE(`unresolved_cases`)"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 2, "widgetType": "counter", "frame": {"title": "Open cases (backlog-days)", "showTitle": true},
+              "encodings": {"value": {"fieldName": "measure(unresolved)", "displayName": "Unresolved cases", "format": {"type": "number", "abbreviation": "compact", "decimalPlaces": {"type": "max", "places": 1}}, "style": {"color": {"hex": "#094074"}}}}}
+          },
+          "position": {"x": 9, "y": 2, "width": 3, "height": 3}
+        },
+        {
+          "widget": {
+            "name": "hero-churn-by-region",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_metrics", "fields": [
+              {"name": "weekly(date)", "expression": "DATE_TRUNC(\"WEEK\", `date`)"},
+              {"name": "measure(churn)", "expression": "MEASURE(`churn_risk_index`)"},
+              {"name": "region", "expression": "`region`"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 3, "widgetType": "line", "frame": {"title": "Churn-risk index by region (weekly)", "showTitle": true},
+              "encodings": {
+                "x": {"fieldName": "weekly(date)", "scale": {"type": "temporal"}, "displayName": "Week"},
+                "y": {"fieldName": "measure(churn)", "scale": {"type": "quantitative"}, "displayName": "Churn-risk index"},
+                "color": {"fieldName": "region", "scale": {"type": "categorical", "mappings": [
+                  {"value": "EMEA", "color": "#FE9000"}, {"value": "NA", "color": "#094074"},
+                  {"value": "APAC", "color": "#3C6997"}, {"value": "LATAM", "color": "#5ADBFF"}
+                ]}, "displayName": "Region"}
+              }}
+          },
+          "position": {"x": 0, "y": 5, "width": 12, "height": 6}
+        },
+        {
+          "widget": {
+            "name": "ontime-by-region",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_metrics", "fields": [
+              {"name": "weekly(date)", "expression": "DATE_TRUNC(\"WEEK\", `date`)"},
+              {"name": "measure(on_time)", "expression": "MEASURE(`on_time_delivery_rate`)"},
+              {"name": "region", "expression": "`region`"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 3, "widgetType": "line", "frame": {"title": "On-time delivery rate by region (weekly)", "showTitle": true},
+              "encodings": {
+                "x": {"fieldName": "weekly(date)", "scale": {"type": "temporal"}, "displayName": "Week"},
+                "y": {"fieldName": "measure(on_time)", "scale": {"type": "quantitative"}, "format": {"type": "number-percent"}, "displayName": "On-time rate"},
+                "color": {"fieldName": "region", "scale": {"type": "categorical", "mappings": [
+                  {"value": "EMEA", "color": "#FE9000"}, {"value": "NA", "color": "#094074"},
+                  {"value": "APAC", "color": "#3C6997"}, {"value": "LATAM", "color": "#5ADBFF"}
+                ]}, "displayName": "Region"}
+              }}
+          },
+          "position": {"x": 0, "y": 11, "width": 6, "height": 6}
+        },
+        {
+          "widget": {
+            "name": "case-surge",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_metrics", "fields": [
+              {"name": "weekly(date)", "expression": "DATE_TRUNC(\"WEEK\", `date`)"},
+              {"name": "measure(unresolved)", "expression": "MEASURE(`unresolved_cases`)"},
+              {"name": "measure(shipping)", "expression": "MEASURE(`shipping_delay_cases`)"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 3, "widgetType": "line", "frame": {"title": "Unresolved & shipping-delay cases (weekly)", "showTitle": true},
+              "encodings": {
+                "x": {"fieldName": "weekly(date)", "scale": {"type": "temporal"}, "displayName": "Week"},
+                "y": {"scale": {"type": "quantitative"}, "displayName": "Cases (backlog-days)", "fields": [
+                  {"fieldName": "measure(unresolved)", "displayName": "Unresolved cases"},
+                  {"fieldName": "measure(shipping)", "displayName": "Shipping-delay cases"}
+                ]},
+                "color": {"scale": {"type": "categorical", "mappings": [
+                  {"value": "Unresolved cases", "color": "#094074"},
+                  {"value": "Shipping-delay cases", "color": "#FE9000"}
+                ]}}
+              }}
+          },
+          "position": {"x": 6, "y": 11, "width": 6, "height": 6}
+        },
+        {
+          "widget": {
+            "name": "churn-forecast",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_forecast", "fields": [
+              {"name": "week", "expression": "`week`"},
+              {"name": "churn", "expression": "`churn`"},
+              {"name": "churn_forecast", "expression": "`churn_forecast`"},
+              {"name": "churn_upper", "expression": "`churn_upper`"},
+              {"name": "churn_lower", "expression": "`churn_lower`"}
+            ], "disaggregated": true}}],
+            "spec": {"version": 1, "widgetType": "forecast-line", "frame": {"title": "Churn-risk index — actuals + forecast (EMEA)", "showTitle": true},
+              "encodings": {
+                "x": {"fieldName": "week", "scale": {"type": "temporal"}, "displayName": "Week"},
+                "y": {"scale": {"type": "quantitative", "domainMin": 0},
+                  "original": {"fieldName": "churn", "displayName": "Churn-risk index (EMEA)"},
+                  "prediction": {"fieldName": "churn_forecast", "displayName": "Forecast"},
+                  "predictionUpper": {"fieldName": "churn_upper"},
+                  "predictionLower": {"fieldName": "churn_lower"}}
+              },
+              "annotations": [{"type": "vertical-line", "encodings": {
+                "x": {"dataValue": "2026-07-03T00:00:00.000", "dataType": "DATETIME"},
+                "label": {"value": "EMEA fulfillment slip begins"},
+                "color": {"value": {"hex": "#FE9000"}}
+              }}]}
+          },
+          "position": {"x": 0, "y": 17, "width": 12, "height": 6}
+        }
+      ]
+    },
+    {
+      "name": "investigation",
+      "displayName": "Investigation",
+      "pageType": "PAGE_TYPE_CANVAS",
+      "layoutVersion": "GRID_V1",
+      "layout": [
+        {
+          "widget": {
+            "name": "inv-header",
+            "multilineTextboxSpec": {
+              "lines": [
+                "# Investigation — why is churn risk up?\n",
+                "Same data split by the dimensions that matter: which regions/segments are exposed, which named accounts carry the ~$1.4M renewal risk, and what's driving the support cases. **EMEA separates from every other region; shipping-delay cases dominate.**"
+              ]
+            }
+          },
+          "position": {"x": 0, "y": 0, "width": 12, "height": 2}
+        },
+        {
+          "widget": {
+            "name": "churn-by-region-segment",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_accounts", "fields": [
+              {"name": "region", "expression": "`region`"},
+              {"name": "measure(Avg Churn Index)", "expression": "MEASURE(`Avg Churn Index`)"},
+              {"name": "segment", "expression": "`segment`"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 3, "widgetType": "bar", "frame": {"title": "Churn-risk index by region & segment", "showTitle": true},
+              "encodings": {
+                "x": {"fieldName": "region", "scale": {"type": "categorical"}, "displayName": "Region"},
+                "y": {"fieldName": "measure(Avg Churn Index)", "scale": {"type": "quantitative"}, "displayName": "Avg churn-risk index"},
+                "color": {"fieldName": "segment", "scale": {"type": "categorical", "mappings": [
+                  {"value": "Enterprise", "color": "#094074"}, {"value": "Mid-Market", "color": "#3C6997"}, {"value": "SMB", "color": "#5ADBFF"}
+                ]}, "displayName": "Segment"}
+              }}
+          },
+          "position": {"x": 0, "y": 2, "width": 6, "height": 6}
+        },
+        {
+          "widget": {
+            "name": "arr-at-risk-by-region",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_accounts", "fields": [
+              {"name": "region", "expression": "`region`"},
+              {"name": "measure(ARR at Risk)", "expression": "MEASURE(`ARR at Risk`)"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 3, "widgetType": "bar", "frame": {"title": "ARR at risk by region", "showTitle": true},
+              "encodings": {
+                "y": {"fieldName": "region", "scale": {"type": "categorical"}, "displayName": "Region"},
+                "x": {"fieldName": "measure(ARR at Risk)", "scale": {"type": "quantitative"}, "format": {"type": "number-currency", "currencyCode": "USD", "abbreviation": "compact"}, "displayName": "ARR at risk"},
+                "color": {"fieldName": "region", "scale": {"type": "categorical", "mappings": [
+                  {"value": "EMEA", "color": "#FE9000"}, {"value": "NA", "color": "#094074"},
+                  {"value": "APAC", "color": "#3C6997"}, {"value": "LATAM", "color": "#5ADBFF"}
+                ]}}
+              }}
+          },
+          "position": {"x": 6, "y": 2, "width": 6, "height": 6}
+        },
+        {
+          "widget": {
+            "name": "at-risk-table",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_at_risk", "fields": [
+              {"name": "account_name", "expression": "`account_name`"},
+              {"name": "country", "expression": "`country`"},
+              {"name": "arr_usd", "expression": "`arr_usd`"},
+              {"name": "days_to_renewal", "expression": "`days_to_renewal`"},
+              {"name": "churn_risk_index", "expression": "`churn_risk_index`"},
+              {"name": "open_cases_30d", "expression": "`open_cases_30d`"},
+              {"name": "on_time_rate_30d", "expression": "`on_time_rate_30d`"}
+            ], "disaggregated": true}}],
+            "spec": {"version": 2, "widgetType": "table", "frame": {"title": "Top at-risk EMEA Enterprise accounts (~$1.4M ARR)", "showTitle": true},
+              "encodings": {"columns": [
+                {"fieldName": "account_name", "displayName": "Account"},
+                {"fieldName": "country", "displayName": "Country"},
+                {"fieldName": "arr_usd", "displayName": "ARR", "format": {"type": "number-currency", "currencyCode": "USD", "abbreviation": "compact", "decimalPlaces": {"type": "max", "places": 1}}},
+                {"fieldName": "days_to_renewal", "displayName": "Days to renewal"},
+                {"fieldName": "churn_risk_index", "displayName": "Churn index", "format": {"type": "number", "decimalPlaces": {"type": "exact", "places": 2}}},
+                {"fieldName": "open_cases_30d", "displayName": "Open cases (30d)"},
+                {"fieldName": "on_time_rate_30d", "displayName": "On-time (30d)", "format": {"type": "number-percent", "decimalPlaces": {"type": "exact", "places": 0}}}
+              ]}}
+          },
+          "position": {"x": 0, "y": 8, "width": 12, "height": 6}
+        },
+        {
+          "widget": {
+            "name": "cases-by-category",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_cases", "fields": [
+              {"name": "category", "expression": "`category`"},
+              {"name": "case_count", "expression": "`case_count`"}
+            ], "disaggregated": true}}],
+            "spec": {"version": 3, "widgetType": "bar", "frame": {"title": "EMEA cases by category", "showTitle": true},
+              "encodings": {
+                "y": {"fieldName": "category", "scale": {"type": "categorical"}, "displayName": "Category"},
+                "x": {"fieldName": "case_count", "scale": {"type": "quantitative"}, "displayName": "Cases"},
+                "color": {"fieldName": "category", "scale": {"type": "categorical", "mappings": [
+                  {"value": "shipping_delay", "color": "#FE9000"}
+                ]}}
+              }}
+          },
+          "position": {"x": 0, "y": 14, "width": 6, "height": 6}
+        },
+        {
+          "widget": {
+            "name": "late-orders-by-region",
+            "queries": [{"name": "main_query", "query": {"datasetName": "ds_metrics", "fields": [
+              {"name": "weekly(date)", "expression": "DATE_TRUNC(\"WEEK\", `date`)"},
+              {"name": "measure(late)", "expression": "MEASURE(`late_orders`)"},
+              {"name": "region", "expression": "`region`"}
+            ], "disaggregated": false}}],
+            "spec": {"version": 3, "widgetType": "bar", "frame": {"title": "Late orders by region (weekly)", "showTitle": true},
+              "encodings": {
+                "x": {"fieldName": "weekly(date)", "scale": {"type": "temporal"}, "displayName": "Week"},
+                "y": {"fieldName": "measure(late)", "scale": {"type": "quantitative"}, "displayName": "Late orders"},
+                "color": {"fieldName": "region", "scale": {"type": "categorical", "mappings": [
+                  {"value": "EMEA", "color": "#FE9000"}, {"value": "NA", "color": "#094074"},
+                  {"value": "APAC", "color": "#3C6997"}, {"value": "LATAM", "color": "#5ADBFF"}
+                ]}, "displayName": "Region"}
+              }}
+          },
+          "position": {"x": 6, "y": 14, "width": 6, "height": 6}
+        }
+      ]
+    },
+    {
+      "name": "filters",
+      "displayName": "Filters",
+      "pageType": "PAGE_TYPE_GLOBAL_FILTERS",
+      "layoutVersion": "GRID_V1",
+      "layout": [
+        {
+          "widget": {
+            "name": "filter-date",
+            "queries": [{"name": "f_date", "query": {"datasetName": "ds_metrics", "fields": [{"name": "date", "expression": "`date`"}], "disaggregated": false}}],
+            "spec": {"version": 2, "widgetType": "filter-date-range-picker", "frame": {"title": "Date range", "showTitle": true},
+              "encodings": {"fields": [{"fieldName": "date", "queryName": "f_date"}]}}
+          },
+          "position": {"x": 0, "y": 0, "width": 4, "height": 2}
+        },
+        {
+          "widget": {
+            "name": "filter-region",
+            "queries": [
+              {"name": "f_region_m", "query": {"datasetName": "ds_metrics", "fields": [{"name": "region", "expression": "`region`"}], "disaggregated": false}},
+              {"name": "f_region_a", "query": {"datasetName": "ds_accounts", "fields": [{"name": "region", "expression": "`region`"}], "disaggregated": false}}
+            ],
+            "spec": {"version": 2, "widgetType": "filter-multi-select", "frame": {"title": "Region", "showTitle": true},
+              "encodings": {"fields": [
+                {"fieldName": "region", "queryName": "f_region_m"},
+                {"fieldName": "region", "queryName": "f_region_a"}
+              ]}}
+          },
+          "position": {"x": 4, "y": 0, "width": 4, "height": 2}
+        },
+        {
+          "widget": {
+            "name": "filter-segment",
+            "queries": [
+              {"name": "f_segment_m", "query": {"datasetName": "ds_metrics", "fields": [{"name": "segment", "expression": "`segment`"}], "disaggregated": false}},
+              {"name": "f_segment_a", "query": {"datasetName": "ds_accounts", "fields": [{"name": "segment", "expression": "`segment`"}], "disaggregated": false}}
+            ],
+            "spec": {"version": 2, "widgetType": "filter-multi-select", "frame": {"title": "Segment", "showTitle": true},
+              "encodings": {"fields": [
+                {"fieldName": "segment", "queryName": "f_segment_m"},
+                {"fieldName": "segment", "queryName": "f_segment_a"}
+              ]}}
+          },
+          "position": {"x": 8, "y": 0, "width": 4, "height": 2}
+        }
+      ]
+    }
+  ],
+  "uiSettings": {
+    "theme": {
+      "canvasBackgroundColor": {"light": "#F5F7FB", "dark": "#0F1419"},
+      "widgetBackgroundColor": {"light": "#FFFFFF", "dark": "#161B22"},
+      "widgetBorderColor": {"light": "#FFFFFF", "dark": "#161B22"},
+      "fontColor": {"light": "#1F2530", "dark": "#E8ECF0"},
+      "selectionColor": {"light": "#4F7CE3", "dark": "#8ACAFF"},
+      "visualizationColors": ["#094074", "#3C6997", "#5ADBFF", "#FFDD4A", "#FE9000"],
+      "widgetHeaderAlignment": "LEFT"
+    },
+    "genieSpace": {
+      "isEnabled": true,
+      "overrideId": "01f192a932571bb1a451e3f754313232",
+      "enablementMode": "ENABLED"
+    }
+  }
+}

--- a/core-platform/cicd/customer-360-lakehouse-genie/src/data_generation/generate_data.py
+++ b/core-platform/cicd/customer-360-lakehouse-genie/src/data_generation/generate_data.py
@@ -1,0 +1,284 @@
+# Databricks notebook source
+"""
+Vela Cloud — Customer 360 Lakehouse
+Synthetic data generation → parquet on UC Volume (raw landing zone for SDP).
+
+Story: an EMEA fulfillment slip (~5 weeks ago) blew out shipping times; late orders
+drove a support-case surge; churn risk hit ~3x on the largest EMEA renewals; a $1.4M
+renewal is exposed. Peak ~3 weeks ago, decaying but still elevated.
+
+Datasets written to /Volumes/{CATALOG}/{SCHEMA}/raw_data/{accounts,orders,cases}
+
+Runs as a bundle setup-job notebook task (serverless `spark` already available).
+catalog/schema come from base_parameters so every task uses the same values.
+"""
+# COMMAND ----------
+
+from pyspark.sql import functions as F
+from pyspark.sql.window import Window
+from datetime import datetime
+import numpy as np
+
+dbutils.widgets.text("catalog", "", "Catalog")
+dbutils.widgets.text("schema", "", "Schema")
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+assert CATALOG and SCHEMA, "catalog + schema are required"
+VOL = f"/Volumes/{CATALOG}/{SCHEMA}/raw_data"
+
+# ---- Time anchors (rolling off today) ----
+NOW = datetime.now().date()
+DAYS_HISTORY = 548  # ~18 months
+SLIP_START_AGO = 35   # EMEA slip begins
+SPIKE_PEAK_AGO = 21   # peak churn / worst on-time / case backlog peak
+DECAY_START_AGO = 14
+
+SEED = 42
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
+spark.sql(f"CREATE VOLUME IF NOT EXISTS {CATALOG}.{SCHEMA}.raw_data")
+
+# COMMAND ----------
+
+# =====================================================================
+# ACCOUNTS (30,000)
+# =====================================================================
+N_ACCOUNTS = 30000
+
+_COMP_A = ["Apex", "Blue", "North", "Summit", "Vertex", "Cedar", "Quantum", "Orbit",
+           "Pioneer", "Nova", "Atlas", "Delta", "Harbor", "Iron", "Silver", "Global"]
+_COMP_B = ["Systems", "Logic", "Dynamics", "Works", "Labs", "Networks", "Digital",
+           "Solutions", "Group", "Analytics", "Cloud", "Data", "Partners", "Industries"]
+_COMP_C = ["Inc", "LLC", "GmbH", "Ltd", "Co", "SA", "AG", "BV"]
+_FIRST = ["Maya", "Liam", "Sofia", "Noah", "Emma", "Lucas", "Olivia", "Ethan",
+          "Ava", "Marco", "Chen", "Priya", "Yuki", "Hans", "Elena", "Diego"]
+_LAST = ["Patel", "Smith", "Garcia", "Muller", "Rossi", "Kim", "Nguyen", "Dubois",
+         "Silva", "Cohen", "Tanaka", "Novak", "Andersen", "Costa", "Fischer", "Weber"]
+
+def _pick(arr, salt):
+    return F.element_at(F.array(*[F.lit(x) for x in arr]),
+                        (F.abs(F.hash(F.col("id") + F.lit(salt))) % len(arr) + 1).cast("int"))
+
+acc = spark.range(0, N_ACCOUNTS, numPartitions=16).withColumn("r", F.rand(SEED))
+# region
+acc = acc.withColumn("region",
+    F.when(F.col("r") < 0.40, F.lit("NA"))
+     .when(F.col("r") < 0.70, F.lit("EMEA"))
+     .when(F.col("r") < 0.90, F.lit("APAC"))
+     .otherwise(F.lit("LATAM")))
+# segment (independent draw)
+acc = acc.withColumn("rs", F.rand(SEED + 1)).withColumn("segment",
+    F.when(F.col("rs") < 0.10, F.lit("Enterprise"))
+     .when(F.col("rs") < 0.40, F.lit("Mid-Market"))
+     .otherwise(F.lit("SMB")))
+# ARR by segment (lognormal-ish via rand bands)
+acc = acc.withColumn("ra", F.rand(SEED + 2)).withColumn("arr_usd",
+    F.when(F.col("segment") == "Enterprise", F.round(80000 + F.col("ra") * 320000, 0))
+     .when(F.col("segment") == "Mid-Market", F.round(15000 + F.col("ra") * 65000, 0))
+     .otherwise(F.round(2000 + F.col("ra") * 13000, 0)))
+# country within region
+acc = acc.withColumn("rc", F.rand(SEED + 3))
+acc = acc.withColumn("country",
+    F.when(F.col("region") == "EMEA",
+        F.when(F.col("rc") < 0.25, "DE").when(F.col("rc") < 0.47, "GB")
+         .when(F.col("rc") < 0.67, "FR").when(F.col("rc") < 0.79, "NL")
+         .when(F.col("rc") < 0.90, "IT").otherwise("ES"))
+     .when(F.col("region") == "NA",
+        F.when(F.col("rc") < 0.85, "US").otherwise("CA"))
+     .when(F.col("region") == "APAC",
+        F.when(F.col("rc") < 0.40, "JP").when(F.col("rc") < 0.70, "AU")
+         .when(F.col("rc") < 0.88, "SG").otherwise("IN"))
+     .otherwise(
+        F.when(F.col("rc") < 0.55, "BR").when(F.col("rc") < 0.80, "MX").otherwise("AR")))
+industries = ["Financial Services", "Healthcare", "Retail", "Manufacturing",
+              "Technology", "Media", "Logistics", "Energy"]
+acc = acc.withColumn("industry",
+    F.element_at(F.array(*[F.lit(x) for x in industries]),
+                 (F.col("id") % len(industries) + 1).cast("int")))
+acc = acc.withColumn("employees",
+    F.when(F.col("segment") == "Enterprise", (F.rand(SEED+4)*9000 + 1000).cast("int"))
+     .when(F.col("segment") == "Mid-Market", (F.rand(SEED+4)*900 + 100).cast("int"))
+     .otherwise((F.rand(SEED+4)*90 + 10).cast("int")))
+# renewal_date: uniform in next 365 days
+acc = acc.withColumn("renewal_offset", (F.rand(SEED+5) * 365 + 1).cast("int"))
+acc = acc.withColumn("renewal_date", F.date_add(F.lit(NOW.isoformat()).cast("date"), F.col("renewal_offset")))
+acc = acc.withColumn("contract_start_date", F.date_sub(F.col("renewal_date"), 365))
+acc = acc.withColumn("signup_date", F.date_sub(F.col("contract_start_date"),
+                                               (F.rand(SEED+6)*720).cast("int")))
+acc = acc.withColumn("account_id", F.concat(F.lit("ACC-"), F.lpad(F.col("id").cast("string"), 6, "0")))
+acc = acc.withColumn("account_name",
+    F.concat_ws(" ", _pick(_COMP_A, 100), _pick(_COMP_B, 200), _pick(_COMP_C, 300)))
+acc = acc.withColumn("csm_owner",
+    F.concat_ws(" ", _pick(_FIRST, 400), _pick(_LAST, 500)))
+
+# ---- At-risk cohort: ~14 EMEA Enterprise accounts, renewal in 30-90 days, ARR ~100K each -> sum ~1.4M ----
+emea_ent = acc.filter((F.col("region") == "EMEA") & (F.col("segment") == "Enterprise"))
+w = Window.orderBy(F.col("id"))
+emea_ent_ranked = emea_ent.withColumn("rk", F.row_number().over(w))
+cohort_ids = [row["id"] for row in emea_ent_ranked.filter(F.col("rk") <= 14).select("id").collect()]
+# assign target ARRs summing to ~1,400,000
+rng = np.random.default_rng(SEED)
+target = np.round(rng.uniform(90000, 180000, size=len(cohort_ids)))
+target = np.round(target * (1400000.0 / target.sum()) / 1000.0) * 1000.0  # scale to sum ~1.4M, round to 1k
+cohort_map = {int(i): float(a) for i, a in zip(cohort_ids, target)}
+print(f"Cohort accounts: {len(cohort_ids)}, ARR sum = {target.sum():,.0f}")
+
+# apply via when-chain (small list)
+arr_expr = F.col("arr_usd")
+renew_expr = F.col("renewal_offset")
+for cid, carr in cohort_map.items():
+    arr_expr = F.when(F.col("id") == cid, F.lit(carr)).otherwise(arr_expr)
+# renewal 30-90 days for cohort (deterministic spread)
+for k, cid in enumerate(cohort_ids):
+    renew_expr = F.when(F.col("id") == cid, F.lit(30 + (k * 4) % 60)).otherwise(renew_expr)
+acc = acc.withColumn("arr_usd", arr_expr).withColumn("renewal_offset", renew_expr)
+acc = acc.withColumn("renewal_date", F.date_add(F.lit(NOW.isoformat()).cast("date"), F.col("renewal_offset")))
+acc = acc.withColumn("is_cohort", F.col("id").isin(cohort_ids))
+
+accounts = acc.select(
+    "account_id", "account_name", "region", "country", "segment", "industry",
+    F.col("arr_usd").cast("double").alias("arr_usd"),
+    "contract_start_date", "renewal_date", "csm_owner", "employees", "signup_date",
+    "is_cohort")
+
+# inject ~0.5% dirty rows (bad region / null arr) for expectations to drop
+dirty = accounts.sample(0.005, seed=SEED).withColumn("region", F.lit("ZZ")) \
+    .withColumn("arr_usd", F.lit(-1.0))
+accounts_out = accounts.unionByName(dirty)
+accounts_out.write.mode("overwrite").parquet(f"{VOL}/accounts")
+print("accounts written:", accounts_out.count())
+
+# save clean accounts as delta for FK lookups
+accounts.write.mode("overwrite").saveAsTable(f"{CATALOG}.{SCHEMA}._gen_accounts")
+acc_lu = spark.table(f"{CATALOG}.{SCHEMA}._gen_accounts").select("account_id", "region", "segment", "is_cohort")
+
+# COMMAND ----------
+
+# =====================================================================
+# ORDERS (~550K)
+# =====================================================================
+N_ORDERS = 550000
+# assign orders to accounts by hash; join region
+orders = spark.range(0, N_ORDERS, numPartitions=32)
+orders = orders.withColumn("acc_idx", (F.abs(F.hash(F.col("id"))) % N_ACCOUNTS))
+orders = orders.withColumn("account_id", F.concat(F.lit("ACC-"), F.lpad(F.col("acc_idx").cast("string"), 6, "0")))
+orders = orders.join(acc_lu, "account_id", "left")
+# order_date uniform over history
+orders = orders.withColumn("days_back", (F.rand(SEED+10) * DAYS_HISTORY).cast("int"))
+orders = orders.withColumn("order_date", F.date_sub(F.lit(NOW.isoformat()).cast("date"), F.col("days_back")))
+orders = orders.withColumn("days_ago", F.datediff(F.lit(NOW.isoformat()).cast("date"), F.col("order_date")))
+orders = orders.withColumn("promised_ship_date", F.date_add(F.col("order_date"), 3))
+# EMEA late-rate ramp
+emea = (F.col("region") == "EMEA")
+da = F.col("days_ago")
+late_rate = (
+    F.when(~emea, F.lit(0.08))
+     .when((da >= 21) & (da <= 35), 0.08 + (35 - da) / 14.0 * (0.45 - 0.08))
+     .when((da >= 0) & (da < 21), 0.20 + da / 21.0 * (0.45 - 0.20))
+     .otherwise(F.lit(0.08)))
+orders = orders.withColumn("late_rate", late_rate)
+orders = orders.withColumn("is_late_draw", F.rand(SEED+11) < F.col("late_rate"))
+orders = orders.withColumn("delay_days",
+    F.when(F.col("is_late_draw"), (F.rand(SEED+12) * 8 + 4).cast("int"))
+     .otherwise((F.rand(SEED+12) * 2 - 1).cast("int")))  # -1..0
+orders = orders.withColumn("actual_ship_date", F.date_add(F.col("promised_ship_date"), F.col("delay_days")))
+orders = orders.withColumn("amount_usd", F.round(F.rand(SEED+13) * 4800 + 200, 2))
+carriers = ["DHL", "FedEx", "UPS", "TNT", "Local"]
+orders = orders.withColumn("carrier",
+    F.element_at(F.array(*[F.lit(x) for x in carriers]), (F.abs(F.hash(F.col("id"))) % 5 + 1).cast("int")))
+orders = orders.withColumn("status",
+    F.when(F.col("days_ago") < 2, F.lit("in_transit")).otherwise(F.lit("delivered")))
+orders = orders.withColumn("order_id",
+    F.concat(F.lit("ORD-"), F.date_format(F.col("order_date"), "yyyyMMdd"), F.lit("-"),
+             F.lpad(F.col("id").cast("string"), 6, "0")))
+orders_out = orders.select("order_id", "account_id", "region", "order_date",
+    "promised_ship_date", "actual_ship_date",
+    F.col("amount_usd").cast("double").alias("amount_usd"), "status", "carrier")
+# dirty rows: null account, negative amount
+odirty = orders_out.sample(0.004, seed=SEED).withColumn("account_id", F.lit(None).cast("string"))
+orders_out2 = orders_out.unionByName(odirty)
+orders_out2.write.mode("overwrite").parquet(f"{VOL}/orders")
+print("orders written:", orders_out2.count())
+
+# COMMAND ----------
+
+# =====================================================================
+# CASES  (baseline ~200K + EMEA event ~28K)
+# =====================================================================
+def build_cases(df, event=False):
+    df = df.join(acc_lu, "account_id", "left")
+    if not event:
+        df = df.withColumn("days_back", (F.rand(SEED+20) * DAYS_HISTORY).cast("int"))
+        df = df.withColumn("opened_date", F.date_sub(F.lit(NOW.isoformat()).cast("date"), F.col("days_back")))
+        rcat = F.rand(SEED+21)
+        df = df.withColumn("category",
+            F.when(rcat < 0.38, "how_to").when(rcat < 0.60, "billing")
+             .when(rcat < 0.78, "product_bug").when(rcat < 0.90, "feature_request")
+             .otherwise("shipping_delay"))
+        # baseline: essentially all resolved (short intervals)
+        df = df.withColumn("res_delay",
+            F.when(F.rand(SEED+22) < 0.85, (F.rand(SEED+23) * 5 + 1).cast("int"))
+             .otherwise((F.rand(SEED+23) * 13 + 7).cast("int")))
+        df = df.withColumn("resolved_date", F.date_add(F.col("opened_date"), F.col("res_delay")))
+        # if resolved in future (recent case), keep open
+        df = df.withColumn("resolved_date",
+            F.when(F.col("resolved_date") > F.lit(NOW.isoformat()).cast("date"), F.lit(None).cast("date"))
+             .otherwise(F.col("resolved_date")))
+        df = df.withColumn("priority",
+            F.when(F.rand(SEED+24) < 0.15, "P1").when(F.rand(SEED+24) < 0.5, "P2").otherwise("P3"))
+        df = df.withColumn("csat",
+            F.when(F.col("resolved_date").isNotNull(), (F.rand(SEED+25) * 2 + 3).cast("int"))
+             .otherwise(F.lit(None).cast("int")))
+        df = df.withColumn("subject", F.concat(F.lit("Case: "), F.col("category")))
+    else:
+        # EMEA event: shipping_delay, opened in slip window (days_ago 14-35, peak ~21), mostly unresolved
+        df = df.filter(F.col("region") == "EMEA")
+        # concentrate opened around peak: triangular-ish via two rands
+        df = df.withColumn("da", (14 + F.rand(SEED+30) * 21).cast("int"))  # 14..35
+        df = df.withColumn("opened_date", F.date_sub(F.lit(NOW.isoformat()).cast("date"), F.col("da")))
+        df = df.withColumn("category", F.lit("shipping_delay"))
+        # 40% resolved recently (recovery), 60% still open
+        df = df.withColumn("resolved_date",
+            F.when(F.rand(SEED+31) < 0.40,
+                   F.date_sub(F.lit(NOW.isoformat()).cast("date"), (F.rand(SEED+32) * 10).cast("int")))
+             .otherwise(F.lit(None).cast("date")))
+        df = df.withColumn("priority", F.when(F.rand(SEED+33) < 0.5, "P1").otherwise("P2"))
+        df = df.withColumn("csat",
+            F.when(F.col("resolved_date").isNotNull(), (F.rand(SEED+34) * 2 + 1).cast("int"))
+             .otherwise(F.lit(None).cast("int")))
+        df = df.withColumn("subject", F.lit("Case: shipping_delay — delayed shipment"))
+    df = df.withColumn("open_hour", (F.rand(SEED+26) * 86400).cast("int"))
+    df = df.withColumn("opened_at", (F.col("opened_date").cast("timestamp") + F.expr("make_interval(0,0,0,0,0,0, open_hour)")))
+    df = df.withColumn("resolved_at",
+        F.when(F.col("resolved_date").isNotNull(), F.col("resolved_date").cast("timestamp")).otherwise(F.lit(None).cast("timestamp")))
+    df = df.withColumn("status",
+        F.when(F.col("resolved_date").isNotNull(), F.lit("resolved"))
+         .when(F.rand(SEED+27) < 0.5, F.lit("open")).otherwise(F.lit("pending")))
+    return df.select("id", "account_id", "region", "opened_at", "resolved_at",
+                     "status", "priority", "category", "subject", "csat")
+
+N_BASE = 200000
+N_EVENT = 95000  # ~30% land in EMEA after the region filter -> ~28K event cases
+base = spark.range(0, N_BASE, numPartitions=16)
+base = base.withColumn("acc_idx", (F.abs(F.hash(F.col("id") + F.lit(7))) % N_ACCOUNTS))
+base = base.withColumn("account_id", F.concat(F.lit("ACC-"), F.lpad(F.col("acc_idx").cast("string"), 6, "0")))
+base = build_cases(base, event=False)
+
+evt = spark.range(N_BASE, N_BASE + N_EVENT, numPartitions=8)
+evt = evt.withColumn("acc_idx", (F.abs(F.hash(F.col("id") + F.lit(7))) % N_ACCOUNTS))
+evt = evt.withColumn("account_id", F.concat(F.lit("ACC-"), F.lpad(F.col("acc_idx").cast("string"), 6, "0")))
+evt = build_cases(evt, event=True)
+
+cases_all = base.unionByName(evt)
+cases_all = cases_all.withColumn("case_id", F.concat(F.lit("CASE-"), F.lpad(F.col("id").cast("string"), 7, "0")))
+cases_out = cases_all.select("case_id", "account_id", "region", "opened_at", "resolved_at",
+    "status", "priority", "category", "subject", F.col("csat").cast("int").alias("csat"))
+# dirty: null account
+cdirty = cases_out.sample(0.004, seed=SEED).withColumn("account_id", F.lit(None).cast("string"))
+cases_out2 = cases_out.unionByName(cdirty)
+cases_out2.write.mode("overwrite").parquet(f"{VOL}/cases")
+print("cases written:", cases_out2.count())
+
+# cleanup temp
+spark.sql(f"DROP TABLE IF EXISTS {CATALOG}.{SCHEMA}._gen_accounts")
+print("DONE")

--- a/core-platform/cicd/customer-360-lakehouse-genie/src/genie/genie_space.json
+++ b/core-platform/cicd/customer-360-lakehouse-genie/src/genie/genie_space.json
@@ -1,0 +1,105 @@
+{
+  "version": 2,
+  "config": {
+    "sample_questions": [
+      {"id": "10000000000000000000000000000001", "question": ["What's our churn-risk index by region this quarter, and how does it compare to baseline?"]},
+      {"id": "10000000000000000000000000000002", "question": ["Show on-time delivery rate by region over the last 12 weeks."]},
+      {"id": "10000000000000000000000000000003", "question": ["How have EMEA unresolved cases and shipping-delay cases trended over the last 12 weeks?"]},
+      {"id": "10000000000000000000000000000004", "question": ["Which account segments are most exposed to the churn-risk spike?"]},
+      {"id": "10000000000000000000000000000005", "question": ["Which EMEA Enterprise accounts are at risk and how much ARR is exposed?"]},
+      {"id": "10000000000000000000000000000006", "question": ["Is EMEA on-time delivery recovering? Show the last 6 weeks."]}
+    ]
+  },
+  "data_sources": {
+    "tables": [
+      {"identifier": "<your_catalog>.customer_360_demo.gold_account_health"},
+      {"identifier": "<your_catalog>.customer_360_demo.mv_customer_health"},
+      {"identifier": "<your_catalog>.customer_360_demo.silver_accounts"},
+      {"identifier": "<your_catalog>.customer_360_demo.silver_cases"},
+      {"identifier": "<your_catalog>.customer_360_demo.silver_orders"}
+    ]
+  },
+  "instructions": {
+    "example_question_sqls": [
+      {
+        "id": "20000000000000000000000000000001",
+        "question": ["What's our churn-risk index by region this quarter, and how does it compare to baseline?"],
+        "sql": [
+          "SELECT date_trunc('week', `date`) AS week, region,\n",
+          "  ROUND(MEASURE(`churn_risk_index`), 2) AS churn_risk_index\n",
+          "FROM <your_catalog>.customer_360_demo.mv_customer_health\n",
+          "WHERE `date` >= date_sub(current_date(), 84)\n",
+          "GROUP BY 1, 2 ORDER BY 1, 2"
+        ]
+      },
+      {
+        "id": "20000000000000000000000000000002",
+        "question": ["Show on-time delivery rate by region over the last 12 weeks."],
+        "sql": [
+          "SELECT date_trunc('week', `date`) AS week, region,\n",
+          "  ROUND(MEASURE(`on_time_delivery_rate`), 3) AS on_time_delivery_rate\n",
+          "FROM <your_catalog>.customer_360_demo.mv_customer_health\n",
+          "WHERE `date` >= date_sub(current_date(), 84)\n",
+          "GROUP BY 1, 2 ORDER BY 1, 2"
+        ]
+      },
+      {
+        "id": "20000000000000000000000000000003",
+        "question": ["How have EMEA unresolved cases and shipping-delay cases trended over the last 12 weeks?"],
+        "sql": [
+          "SELECT date_trunc('week', `date`) AS week,\n",
+          "  ROUND(MEASURE(`unresolved_cases`)) AS unresolved_cases,\n",
+          "  ROUND(MEASURE(`shipping_delay_cases`)) AS shipping_delay_cases\n",
+          "FROM <your_catalog>.customer_360_demo.mv_customer_health\n",
+          "WHERE region = 'EMEA' AND `date` >= date_sub(current_date(), 84)\n",
+          "GROUP BY 1 ORDER BY 1"
+        ]
+      },
+      {
+        "id": "20000000000000000000000000000004",
+        "question": ["Which account segments are most exposed to the churn-risk spike?"],
+        "sql": [
+          "SELECT region, segment,\n",
+          "  ROUND(AVG(churn_risk_index), 2) AS avg_churn_risk_index,\n",
+          "  COUNT(*) AS accounts\n",
+          "FROM <your_catalog>.customer_360_demo.gold_account_health\n",
+          "GROUP BY region, segment ORDER BY avg_churn_risk_index DESC"
+        ]
+      },
+      {
+        "id": "20000000000000000000000000000005",
+        "question": ["Which EMEA Enterprise accounts are at risk and how much ARR is exposed?"],
+        "sql": [
+          "SELECT account_name, country, arr_usd, days_to_renewal, churn_risk_index, open_cases_30d, on_time_rate_30d\n",
+          "FROM <your_catalog>.customer_360_demo.gold_account_health\n",
+          "WHERE region = 'EMEA' AND segment = 'Enterprise' AND is_at_risk\n",
+          "ORDER BY arr_usd DESC"
+        ]
+      },
+      {
+        "id": "20000000000000000000000000000006",
+        "question": ["Is EMEA on-time delivery recovering? Show the last 6 weeks."],
+        "sql": [
+          "SELECT date_trunc('week', `date`) AS week,\n",
+          "  ROUND(MEASURE(`on_time_delivery_rate`), 3) AS on_time_delivery_rate\n",
+          "FROM <your_catalog>.customer_360_demo.mv_customer_health\n",
+          "WHERE region = 'EMEA' AND `date` >= date_sub(current_date(), 42)\n",
+          "GROUP BY 1 ORDER BY 1"
+        ]
+      }
+    ],
+    "text_instructions": [
+      {
+        "id": "30000000000000000000000000000001",
+        "content": [
+          "You analyze Vela Cloud customer-360 data for Maya Patel (VP Customer Experience, non-technical). Be concise and business-friendly; lead with the number and the 'so what'.\n\n",
+          "WHAT HAPPENED: ~5 weeks ago an EMEA fulfillment slip blew out shipping times; late orders drove a support-case surge; the churn-risk index spiked to ~3x on the largest EMEA renewals; ~$1.4M of ARR is exposed. It peaked ~3 weeks ago and is now decaying but still elevated.\n\n",
+          "BASELINES: normal churn-risk index ~1.0x; normal on-time delivery ~92%; EMEA unresolved-case load normally steady. Anomaly = churn-risk index > ~2x or on-time delivery < ~75%.\n\n",
+          "HEADLINE NUMBERS — always answer from mv_customer_health (same definitions the dashboard KPI tiles use, so numbers match exactly): churn risk -> MEASURE(`churn_risk_index`); on-time delivery -> MEASURE(`on_time_delivery_rate`); ARR-at-risk trend -> MEASURE(`arr_at_risk`); cases -> MEASURE(`unresolved_cases`), MEASURE(`shipping_delay_cases`), MEASURE(`new_cases`). Dimensions are `date`, region, segment.\n\n",
+          "PER-ACCOUNT questions (which accounts, how much ARR, renewal dates) come from gold_account_health (one row per account: churn_risk_index, region, segment, arr_usd, renewal_date, days_to_renewal, is_at_risk, open_cases_30d, on_time_rate_30d). The crisp '$1.4M at risk' = SUM(arr_usd) WHERE is_at_risk.\n\n",
+          "INVESTIGATION FLOW for 'Why is churn risk spiking?': (1) mv_customer_health churn_risk_index by week by region -> EMEA ~3x ~3 weeks ago, others flat ~1x. (2) mv_customer_health on_time_delivery_rate by week for EMEA -> collapses ~92% -> ~55% same window. (3) mv_customer_health unresolved_cases + shipping_delay_cases by week for EMEA -> surge tracks the delivery drop. (4) gold_account_health GROUP BY region, segment ORDER BY AVG churn_risk_index DESC -> EMEA Enterprise most exposed. (5) gold_account_health WHERE region='EMEA' AND segment='Enterprise' AND is_at_risk -> top accounts by arr_usd, SUM ~= $1.4M. Conclude: delayed EMEA shipments drove the support surge and the churn-risk spike; exposure concentrates in a handful of EMEA Enterprise renewals worth ~$1.4M.\n"
+        ]
+      }
+    ]
+  }
+}

--- a/core-platform/cicd/customer-360-lakehouse-genie/src/jobs/validate_metrics.py
+++ b/core-platform/cicd/customer-360-lakehouse-genie/src/jobs/validate_metrics.py
@@ -1,0 +1,40 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Validate Metrics
+# MAGIC Confirms the gold tables are populated after the pipeline run and that the
+# MAGIC governed metric view `mv_customer_health` returns current data for the
+# MAGIC Monday exec review.
+
+# COMMAND ----------
+
+dbutils.widgets.text("catalog", "", "Catalog")
+dbutils.widgets.text("schema", "", "Schema")
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+assert CATALOG and SCHEMA, "catalog + schema are required"
+
+# COMMAND ----------
+
+for t in ["gold_account_health", "gold_daily_health"]:
+    n = spark.table(f"{CATALOG}.{SCHEMA}.{t}").count()
+    print(f"{t}: {n:,} rows")
+    assert n > 0, f"{t} is empty"
+
+# COMMAND ----------
+
+df = spark.sql(f"""
+  SELECT region,
+    ROUND(MEASURE(`churn_risk_index`), 2)      AS churn_risk_index,
+    ROUND(MEASURE(`on_time_delivery_rate`), 3) AS on_time_delivery_rate
+  FROM {CATALOG}.{SCHEMA}.mv_customer_health
+  WHERE `date` >= date_sub(current_date(), 21)
+  GROUP BY region ORDER BY churn_risk_index DESC
+""")
+df.show()
+
+arr = spark.sql(f"""
+  SELECT ROUND(SUM(arr_usd), 0) AS arr_at_risk_usd, COUNT(*) AS at_risk_accounts
+  FROM {CATALOG}.{SCHEMA}.gold_account_health WHERE is_at_risk
+""").collect()[0]
+print(f"ARR at risk: ${arr['arr_at_risk_usd']:,.0f} across {arr['at_risk_accounts']} accounts")
+print("Metrics refreshed and validated — customer-360 view is fresh")

--- a/core-platform/cicd/customer-360-lakehouse-genie/src/metric_view/mv_customer_health.py
+++ b/core-platform/cicd/customer-360-lakehouse-genie/src/metric_view/mv_customer_health.py
@@ -1,0 +1,84 @@
+# Databricks notebook source
+"""
+Deploy the governed Metric View `mv_customer_health`.
+
+Metric views have no PySpark API — this notebook runs the
+`CREATE OR REPLACE VIEW ... WITH METRICS LANGUAGE YAML` SQL inline, with the
+catalog/schema resolved from base_parameters (so every task uses the same
+values). Source: gold_daily_health (built by the SDP pipeline).
+"""
+# COMMAND ----------
+
+dbutils.widgets.text("catalog", "", "Catalog")
+dbutils.widgets.text("schema", "", "Schema")
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+assert CATALOG and SCHEMA, "catalog + schema are required"
+FQ = f"{CATALOG}.{SCHEMA}"
+
+# COMMAND ----------
+
+ddl = f"""
+CREATE OR REPLACE VIEW {FQ}.mv_customer_health
+WITH METRICS
+LANGUAGE YAML
+AS $$
+version: 1.1
+source: {FQ}.gold_daily_health
+comment: "Governed customer-health KPI layer (churn risk, on-time delivery, ARR at risk, case load) by date/region/segment. Single source of truth for dashboard tiles and Genie answers."
+dimensions:
+  - name: date
+    expr: date
+    comment: "Day"
+  - name: region
+    expr: region
+    comment: "Sales region (NA, EMEA, APAC, LATAM)"
+  - name: segment
+    expr: segment
+    comment: "Customer segment (Enterprise, Mid-Market, SMB)"
+measures:
+  - name: account_count
+    expr: SUM(account_count)
+  - name: arr_total
+    expr: SUM(arr_total_usd)
+  - name: arr_at_risk
+    expr: SUM(arr_at_risk_usd)
+    comment: "ARR exposed to churn in the affected cohort"
+  - name: new_cases
+    expr: SUM(new_cases)
+  - name: unresolved_cases
+    expr: SUM(unresolved_cases)
+  - name: shipping_delay_cases
+    expr: SUM(shipping_delay_cases)
+  - name: orders_count
+    expr: SUM(orders_count)
+  - name: late_orders
+    expr: SUM(late_orders)
+  - name: on_time_delivery_rate
+    expr: SUM(on_time_orders) / NULLIF(SUM(orders_count), 0)
+    comment: "On-time delivery rate; baseline ~0.92, EMEA trough ~0.55 during the slip"
+  - name: late_order_rate
+    expr: SUM(late_orders) / NULLIF(SUM(orders_count), 0)
+  - name: churn_risk_index
+    expr: SUM(churn_risk_weighted) / NULLIF(SUM(account_count), 0)
+    comment: "Churn-risk index in [1,3]; baseline ~1.0x, EMEA peak ~3x during the slip"
+$$
+"""
+
+spark.sql(ddl)
+print(f"Metric view ready: {FQ}.mv_customer_health")
+
+# COMMAND ----------
+
+# Smoke test — a MEASURE() query must return rows.
+df = spark.sql(f"""
+  SELECT region,
+    ROUND(MEASURE(`churn_risk_index`), 2)      AS churn_risk_index,
+    ROUND(MEASURE(`on_time_delivery_rate`), 3) AS on_time_delivery_rate
+  FROM {FQ}.mv_customer_health
+  WHERE `date` >= date_sub(current_date(), 21)
+  GROUP BY region ORDER BY churn_risk_index DESC
+""")
+df.show()
+assert df.count() > 0, "metric view returned no rows"
+print("Metric view validated")

--- a/core-platform/cicd/customer-360-lakehouse-genie/src/pipeline/01_bronze.py
+++ b/core-platform/cicd/customer-360-lakehouse-genie/src/pipeline/01_bronze.py
@@ -1,0 +1,47 @@
+# Bronze — streaming ingestion (Auto Loader) + data-quality expectations.
+#
+# The raw landing volume path is passed in as a pipeline configuration value
+# (`demo.volume_path`) — SDP SQL `read_files(...)` can't interpolate conf vars,
+# so bronze is authored in Python where `spark.conf.get(...)` works. This keeps
+# the path correct by resolving catalog/schema through the schema resource.
+import dlt
+from pyspark.sql import SparkSession
+
+spark = SparkSession.getActiveSession()
+VOL = spark.conf.get("demo.volume_path")
+
+
+def _read(subpath):
+    return (
+        spark.readStream.format("cloudFiles")
+        .option("cloudFiles.format", "parquet")
+        .option("cloudFiles.inferColumnTypes", "true")
+        .load(f"{VOL}/{subpath}")
+    )
+
+
+@dlt.table(name="bronze_accounts",
+           comment="Raw CRM accounts landed by Lakeflow Connect (Salesforce)")
+@dlt.expect("valid_region", "region IN ('NA','EMEA','APAC','LATAM')")
+@dlt.expect_or_drop("valid_arr", "arr_usd > 0")
+@dlt.expect_or_drop("has_renewal", "renewal_date IS NOT NULL")
+def bronze_accounts():
+    return _read("accounts")
+
+
+@dlt.table(name="bronze_orders",
+           comment="Raw ERP order/fulfillment events")
+@dlt.expect_or_drop("has_account", "account_id IS NOT NULL")
+@dlt.expect_or_drop("valid_amount", "amount_usd >= 0")
+@dlt.expect("promised_set", "promised_ship_date IS NOT NULL")
+def bronze_orders():
+    return _read("orders")
+
+
+@dlt.table(name="bronze_cases",
+           comment="Raw support cases landed by Lakeflow Connect (Zendesk)")
+@dlt.expect_or_drop("has_account", "account_id IS NOT NULL")
+@dlt.expect("valid_status", "status IN ('open','pending','resolved')")
+@dlt.expect_or_drop("opened_not_null", "opened_at IS NOT NULL")
+def bronze_cases():
+    return _read("cases")

--- a/core-platform/cicd/customer-360-lakehouse-genie/src/pipeline/02_silver.sql
+++ b/core-platform/cicd/customer-360-lakehouse-genie/src/pipeline/02_silver.sql
@@ -1,0 +1,36 @@
+-- ---------- SILVER (cleaned + enriched) ----------
+CREATE OR REFRESH MATERIALIZED VIEW silver_accounts
+COMMENT "Cleaned account dimension with renewal proximity"
+AS SELECT
+  account_id, account_name, region, country, segment, industry,
+  arr_usd, contract_start_date, renewal_date, csm_owner, employees, signup_date,
+  is_cohort,
+  DATEDIFF(renewal_date, current_date()) AS days_to_renewal,
+  CASE WHEN DATEDIFF(renewal_date, current_date()) <= 90 THEN '<=90d'
+       WHEN DATEDIFF(renewal_date, current_date()) <= 180 THEN '<=180d'
+       ELSE '>180d' END AS renewal_window
+FROM bronze_accounts;
+
+CREATE OR REFRESH MATERIALIZED VIEW silver_orders
+COMMENT "Order fact with lateness flags, enriched with account segment"
+AS SELECT
+  o.order_id, o.account_id, o.region, a.segment, a.industry,
+  o.order_date, o.promised_ship_date, o.actual_ship_date,
+  o.amount_usd, o.status, o.carrier,
+  (o.actual_ship_date > o.promised_ship_date) AS is_late,
+  DATEDIFF(o.actual_ship_date, o.promised_ship_date) AS ship_delay_days
+FROM bronze_orders o
+JOIN silver_accounts a USING (account_id);
+
+CREATE OR REFRESH MATERIALIZED VIEW silver_cases
+COMMENT "Case fact with resolution + backlog flags, enriched with account segment"
+AS SELECT
+  c.case_id, c.account_id, c.region, a.segment,
+  c.opened_at, c.resolved_at,
+  CAST(c.opened_at AS DATE) AS opened_date,
+  CAST(c.resolved_at AS DATE) AS resolved_date,
+  c.status, c.priority, c.category, c.subject, c.csat,
+  (c.status IN ('open','pending')) AS is_unresolved,
+  DATEDIFF(CAST(c.resolved_at AS DATE), CAST(c.opened_at AS DATE)) AS resolution_days
+FROM bronze_cases c
+JOIN silver_accounts a USING (account_id);

--- a/core-platform/cicd/customer-360-lakehouse-genie/src/pipeline/03_gold.sql
+++ b/core-platform/cicd/customer-360-lakehouse-genie/src/pipeline/03_gold.sql
@@ -1,0 +1,108 @@
+-- ---------- GOLD ----------
+-- Per-account current-snapshot health
+CREATE OR REFRESH MATERIALIZED VIEW gold_account_health
+COMMENT "One row per account: 30-day health + churn risk + at-risk flag"
+AS
+WITH orders30 AS (
+  SELECT account_id,
+         COUNT(*) AS orders_30d,
+         SUM(CASE WHEN is_late THEN 1 ELSE 0 END) AS late_orders_30d
+  FROM silver_orders
+  WHERE order_date >= DATE_SUB(current_date(), 30)
+  GROUP BY account_id
+),
+cases_open AS (
+  SELECT account_id, COUNT(*) AS open_cases_30d
+  FROM silver_cases
+  WHERE is_unresolved
+  GROUP BY account_id
+),
+base AS (
+  SELECT a.*,
+         COALESCE(o.orders_30d, 0) AS orders_30d,
+         COALESCE(o.late_orders_30d, 0) AS late_orders_30d,
+         COALESCE( c.open_cases_30d, 0) AS open_cases_30d
+  FROM silver_accounts a
+  LEFT JOIN orders30 o USING (account_id)
+  LEFT JOIN cases_open c USING (account_id)
+)
+SELECT
+  account_id, account_name, region, country, segment, industry, arr_usd,
+  renewal_date, days_to_renewal, renewal_window,
+  orders_30d, late_orders_30d, open_cases_30d,
+  ROUND(1.0 - late_orders_30d / NULLIF(orders_30d, 0), 3) AS on_time_rate_30d,
+  -- churn components
+  LEAST(1.0, GREATEST(0.0, (late_orders_30d / NULLIF(orders_30d, 0) - 0.08) / (0.45 - 0.08))) AS c_delivery,
+  LEAST(1.0, open_cases_30d / 5.0) AS c_cases,
+  CASE WHEN days_to_renewal <= 90 THEN 1.0 WHEN days_to_renewal <= 180 THEN 0.5 ELSE 0.2 END AS c_renewal,
+  ROUND(100 * (0.5 * LEAST(1.0, GREATEST(0.0, (late_orders_30d / NULLIF(orders_30d, 0) - 0.08) / (0.45 - 0.08)))
+             + 0.3 * LEAST(1.0, open_cases_30d / 5.0)
+             + 0.2 * (CASE WHEN days_to_renewal <= 90 THEN 1.0 WHEN days_to_renewal <= 180 THEN 0.5 ELSE 0.2 END))) AS churn_risk_score,
+  ROUND(1 + 2 * (0.5 * LEAST(1.0, GREATEST(0.0, (late_orders_30d / NULLIF(orders_30d, 0) - 0.08) / (0.45 - 0.08)))
+             + 0.3 * LEAST(1.0, open_cases_30d / 5.0)
+             + 0.2 * (CASE WHEN days_to_renewal <= 90 THEN 1.0 WHEN days_to_renewal <= 180 THEN 0.5 ELSE 0.2 END)), 2) AS churn_risk_index,
+  is_cohort AS is_at_risk,
+  CASE WHEN is_cohort THEN arr_usd ELSE 0 END AS arr_at_risk_usd
+FROM base;
+
+-- Daily time-series by region x segment (metric-view source)
+CREATE OR REFRESH MATERIALIZED VIEW gold_daily_health
+COMMENT "Daily region x segment health metrics: churn index, delivery, case backlog, ARR at risk"
+AS
+WITH spine AS (
+  SELECT explode(sequence(DATE_SUB(current_date(), 548), current_date(), interval 1 day)) AS date
+),
+slices AS (
+  SELECT region, segment,
+         COUNT(*) AS account_count,
+         SUM(arr_usd) AS arr_total_usd,
+         SUM(CASE WHEN is_cohort THEN arr_usd ELSE 0 END) AS cohort_arr
+  FROM silver_accounts
+  GROUP BY region, segment
+),
+orders_daily AS (
+  SELECT order_date AS date, region, segment,
+         COUNT(*) AS orders_count,
+         SUM(CASE WHEN is_late THEN 1 ELSE 0 END) AS late_orders,
+         SUM(CASE WHEN NOT is_late THEN 1 ELSE 0 END) AS on_time_orders
+  FROM silver_orders GROUP BY order_date, region, segment
+),
+new_cases_daily AS (
+  SELECT opened_date AS date, region, segment, COUNT(*) AS new_cases
+  FROM silver_cases GROUP BY opened_date, region, segment
+),
+case_days AS (
+  SELECT explode(sequence(opened_date, COALESCE(resolved_date, current_date()), interval 1 day)) AS date,
+         region, segment, category
+  FROM silver_cases
+),
+backlog_daily AS (
+  SELECT date, region, segment,
+         COUNT(*) AS unresolved_cases,
+         SUM(CASE WHEN category = 'shipping_delay' THEN 1 ELSE 0 END) AS shipping_delay_cases
+  FROM case_days GROUP BY date, region, segment
+),
+joined AS (
+  SELECT sp.date, sl.region, sl.segment, sl.account_count, sl.arr_total_usd, sl.cohort_arr,
+         COALESCE(o.orders_count, 0) AS orders_count,
+         COALESCE(o.late_orders, 0) AS late_orders,
+         COALESCE(o.on_time_orders, 0) AS on_time_orders,
+         COALESCE(nc.new_cases, 0) AS new_cases,
+         COALESCE(b.unresolved_cases, 0) AS unresolved_cases,
+         COALESCE(b.shipping_delay_cases, 0) AS shipping_delay_cases
+  FROM spine sp
+  CROSS JOIN slices sl
+  LEFT JOIN orders_daily o ON o.date = sp.date AND o.region = sl.region AND o.segment = sl.segment
+  LEFT JOIN new_cases_daily nc ON nc.date = sp.date AND nc.region = sl.region AND nc.segment = sl.segment
+  LEFT JOIN backlog_daily b ON b.date = sp.date AND b.region = sl.region AND b.segment = sl.segment
+)
+SELECT
+  date, region, segment, account_count, arr_total_usd,
+  new_cases, unresolved_cases, shipping_delay_cases,
+  orders_count, late_orders, on_time_orders,
+  -- delivery stress -> churn index in [1,3]
+  ROUND((1 + 2 * LEAST(1.0, GREATEST(0.0,
+        (late_orders / NULLIF(orders_count, 0) - 0.08) / (0.45 - 0.08)))) * account_count, 3) AS churn_risk_weighted,
+  ROUND(cohort_arr * LEAST(1.0, GREATEST(0.0,
+        (late_orders / NULLIF(orders_count, 0) - 0.08) / (0.45 - 0.08))), 0) AS arr_at_risk_usd
+FROM joined;


### PR DESCRIPTION
## Description
Adds **Customer 360 Lakehouse** under `core-platform/cicd/customer-360-lakehouse-genie/` — an end-to-end Databricks Asset Bundle whose headline is deploying a **Genie Agent with DABs** (native `genie_spaces` resource, not the SDK/API). Unlike samples-based Genie examples, this bundle **builds its own tables**, so it demonstrates real `genie_spaces` deployment behavior.

## Category
- [x] core-platform

## Type of Change
- [x] New project

## Project Details
**Project Name:** Customer 360 Lakehouse — Genie Agents with DABs, end to end
**Purpose:** A fork-and-adapt reference showing Lakeflow pipelines (bronze→silver→gold with expectations), Metric Views, AI/BI dashboard, and a native Genie space in one bundle — plus the deploy pattern required when Genie binds to tables the bundle itself produces.
**Technologies Used:** Databricks Asset Bundles (direct engine), Lakeflow Declarative Pipelines, Unity Catalog, Metric Views, AI/BI Dashboard + Genie, GitHub Actions / Azure DevOps / GitLab / Jenkins.

## Testing
- [x] Code runs without errors — deployed end-to-end (3-phase) on a dev workspace; pipeline, dashboard, and Genie space created; the space answers the sample questions
- [x] `databricks bundle validate` passes (dev + prod targets)
- [x] Documentation is complete
- [x] Used only synthetic data

## Security Compliance ✅
- [x] No customer data, PII, or proprietary information
- [x] No credentials or access tokens
- [x] Only synthetic data used (numpy-generated)
- [x] Third-party licenses acknowledged (numpy)

## Notes for reviewers
- The Genie space binds to tables the bundle builds, so deploy is a documented **3-phase flow** (deploy all-except-Genie → run the setup job to build tables → full deploy adds Genie). This is inherent to the current `genie_spaces` resource, not an oversight — the table binding also can't be parameterized (`<your_catalog>` placeholder the user edits before first deploy). Both are covered in the README's "Known limitations."
- The nested `.github/workflows/` (and the other three CI/CD files) are intentional template content, inert at this path — they run only when a user copies the template to their own repo root. Same pattern as OrderFlow (#71).

---
**By submitting this PR, I confirm I have followed the CONTRIBUTING.md guidelines and security requirements.**

This pull request and its description were written by Isaac.